### PR TITLE
set: add a FromFunc set constructor

### DIFF
--- a/set.go
+++ b/set.go
@@ -36,6 +36,15 @@ func From[T comparable](items []T) *Set[T] {
 	return s
 }
 
+// FromFunc creates a new Set containing a conversion of each item in items.
+func FromFunc[A any, T comparable](items []A, conversion func(A) T) *Set[T] {
+	s := New[T](len(items))
+	for _, item := range items {
+		s.Insert(conversion(item))
+	}
+	return s
+}
+
 // Set is a simple, generic implementation of the set mathematical data structure.
 // It is optimized for correctness and convenience, as a replacement for the use
 // of map[interface{}]struct{}.

--- a/set_test.go
+++ b/set_test.go
@@ -41,6 +41,16 @@ func TestSet_From(t *testing.T) {
 	})
 }
 
+func TestSet_FromFunc(t *testing.T) {
+	employees := []employee{
+		{"alice", 1}, {"bob", 2}, {"bob", 2}, {"carol", 3}, {"dave", 4},
+	}
+	s := FromFunc(employees, func(e employee) string {
+		return e.name
+	})
+	must.MapContainsKeys(t, s.items, []string{"alice", "bob", "carol", "dave"})
+}
+
 func TestSet_Insert(t *testing.T) {
 	t.Run("one int", func(t *testing.T) {
 		s := New[int](10)


### PR DESCRIPTION
This PR adds FromFunc for conveniently constructing a set from a slice
of objects, where we only care about some comparable aspect of the object.

e.g. - something like this 
```go
names := make([]string, 0, len(employees))
for _, employee := range employees {
    names = append(names, employee.name)
}
```
would become
```go
set.FromFunc(employees, func(e employee) string {return e.Name} )
```