### PR TITLE
set: add HashSet for types that implement Hash() function

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,14 @@ The same result, but in one line using package `go-set`.
 list := set.From[string](items).List()
 ```
 
+# Hash Function
+
+In addition to `Set`, there is `HashSet` for types that implement a `Hash()` function.
+The custom type must satisfy `HashFunc[H Hash]` - essentially any `Hash()`
+function that returns a `string` or `integer`. This enables types to use string-y
+hash functions like `md5`, `sha1`, or even `GoString()`, but also enables types
+to implement an efficient hash function using a hash code based on prime multiples.
+
 ### Methods
 
 Implements the following set operations
@@ -69,9 +77,9 @@ go get github.com/hashicorp/go-set@latest
 import "github.com/hashicorp/go-set"
 ```
 
-# Example
+# Set Examples
 
-Below are simple example of usages
+Below are simple example usages of `Set`
 
 ```go
 s := set.New[int](10)
@@ -91,4 +99,41 @@ s.Remove("one") # true
 a := set.From[int]([]int{2, 4, 6, 8})
 b := set.From[int]([]int{4, 5, 6})
 a.Intersect(b) # {4, 6}
+```
+
+# HashSet Examples
+
+Below are simple example usages of `HashSet`
+
+(using a hash code)
+```
+type inventory struct {
+    item   int
+    serial int
+}
+
+func (i *inventory) Hash() int {
+    code := 3 * item * 5 * serial
+    return code
+}
+
+i1 := &inventory{item: 42, serial: 101}
+s := set.NewHashSet[*inventory, int](10)
+s.Insert(i1)
+```
+
+(using a string hash)
+```
+type employee struct {
+    name string
+    id   int
+}
+
+func (e *employee) Hash() string {
+    return fmt.Sprintf("%s:%d", e.name, e.id)
+}
+
+e1 := &employee{name: "armon", id: 2}
+s := set.NewHashSet[*employee, string](10)
+s.Insert(e1)
 ```

--- a/hashset.go
+++ b/hashset.go
@@ -211,7 +211,7 @@ func (s *HashSet[T, H]) Intersect(o *HashSet[T, H]) *HashSet[T, H] {
 	return result
 }
 
-// Copy creates a copy of s.
+// Copy creates a shallow copy of s.
 func (s *HashSet[T, H]) Copy() *HashSet[T, H] {
 	result := NewHashSet[T, H](s.Size())
 	for key, item := range s.items {

--- a/hashset.go
+++ b/hashset.go
@@ -1,0 +1,266 @@
+package set
+
+import (
+	"fmt"
+	"sort"
+)
+
+// Hash represents the output type of a Hash() function defined on a type.
+//
+// A Hash could be string-like or int-like. A string hash could be something like
+// and md5, sha1, or GoString() representation of a type. An int hash could be
+// something like the prime multiple hash code of a type.
+type Hash interface {
+	~string | ~int | ~uint | ~int64 | ~uint64 | ~int32 | ~uint32 | ~int16 | ~uint16 | ~int8 | ~uint8
+}
+
+// HashFunc is a generic type constraint for any type that implements a Hash()
+// method with a Hash return type.
+type HashFunc[H Hash] interface {
+	Hash() H
+}
+
+// HashSet is a generic implementation of the mathematical data structure, oriented
+// around the use of a HashFunc to make hash values from other types.
+type HashSet[T HashFunc[H], H Hash] struct {
+	items map[H]T
+}
+
+// NewHashSet creates a HashSet with underlying capacity of size.
+//
+// A HashSet will automatically grow or shrink its capacity as items are added
+// or removed.
+//
+// T must implement HashFunc[H], where H is of Hash type. This allows custom types
+// that include non-comparable fields to provide their own hash algorithm.
+func NewHashSet[T HashFunc[H], H Hash](size int) *HashSet[T, H] {
+	return &HashSet[T, H]{
+		items: make(map[H]T, max(0, size)),
+	}
+}
+
+// HashSetFrom creates a new HashSet containing each item in items.
+//
+// T must implement HashFunc[H], where H is of type Hash. This allows custom types
+// that include non-comparable fields to provide their own hash algorithm.
+func HashSetFrom[T HashFunc[H], H Hash](items []T) *HashSet[T, H] {
+	s := NewHashSet[T, H](len(items))
+	s.InsertAll(items)
+	return s
+}
+
+// Insert item into s.
+//
+// Return true if s was modified (item was not already in s), false otherwise.
+func (s *HashSet[T, H]) Insert(item T) bool {
+	key := item.Hash()
+	if _, exists := s.items[key]; exists {
+		return false
+	}
+	s.items[key] = item
+	return true
+}
+
+// InsertAll will insert each item in items into s.
+//
+// Return true if s was modified (at least one item was not already in s), false otherwise.
+func (s *HashSet[T, H]) InsertAll(items []T) bool {
+	modified := false
+	for _, item := range items {
+		if s.Insert(item) {
+			modified = true
+		}
+	}
+	return modified
+}
+
+// InsertSet will insert each element of o into s.
+//
+// Return true if s was modified (at least one item of o was not already in s), false otherwise.
+func (s *HashSet[T, H]) InsertSet(o *HashSet[T, H]) bool {
+	modified := false
+	for key, value := range o.items {
+		if _, exists := s.items[key]; !exists {
+			modified = true
+		}
+		s.items[key] = value
+	}
+	return modified
+}
+
+// Remove will remove item from s.
+//
+// Return true if s was modified (item was present), false otherwise.
+func (s *HashSet[T, H]) Remove(item T) bool {
+	key := item.Hash()
+	if _, exists := s.items[key]; !exists {
+		return false
+	}
+	delete(s.items, key)
+	return true
+}
+
+// RemoveAll will remove each item in items from s.
+//
+// Return true if s was modified (any item was present), false otherwise.
+func (s *HashSet[T, H]) RemoveAll(items []T) bool {
+	modified := false
+	for _, item := range items {
+		if s.Remove(item) {
+			modified = true
+		}
+	}
+	return modified
+}
+
+// RemoveSet will remove each element of o from s.
+//
+// Return true if s was modified (any item of o was present in s), false otherwise.
+func (s *HashSet[T, H]) RemoveSet(o *HashSet[T, H]) bool {
+	modified := false
+	for key := range o.items {
+		if _, exists := s.items[key]; exists {
+			modified = true
+			delete(s.items, key)
+		}
+	}
+	return modified
+}
+
+// Contains returns whether item is present in s.
+func (s *HashSet[T, H]) Contains(item T) bool {
+	_, exists := s.items[item.Hash()]
+	return exists
+}
+
+// ContainsAll returns whether s contains at least every item in items.
+func (s *HashSet[T, H]) ContainsAll(items []T) bool {
+	if len(s.items) < len(items) {
+		return false
+	}
+	for _, item := range items {
+		if !s.Contains(item) {
+			return false
+		}
+	}
+	return true
+}
+
+// ContainsSlice returns whether s contains the same set of of elements
+// that are in items. The elements of items may contain duplicates.
+//
+// If the slice is known to be set-like (no duplicates), EqualSlice provides
+// a more efficient implementation.
+func (s *HashSet[T, H]) ContainsSlice(items []T) bool {
+	return s.Equal(HashSetFrom[T, H](items))
+}
+
+// Subset returns whether o is a subset of s.
+func (s *HashSet[T, H]) Subset(o *HashSet[T, H]) bool {
+	if len(s.items) < len(o.items) {
+		return false
+	}
+	for _, item := range o.items {
+		if !s.Contains(item) {
+			return false
+		}
+	}
+	return true
+}
+
+// Size returns the cardinality of s.
+func (s *HashSet[T, H]) Size() int {
+	return len(s.items)
+}
+
+// Union returns a set that contains all elements of s and o combined.
+func (s *HashSet[T, H]) Union(o *HashSet[T, H]) *HashSet[T, H] {
+	result := NewHashSet[T, H](s.Size())
+	for key, item := range s.items {
+		result.items[key] = item
+	}
+	for key, item := range o.items {
+		result.items[key] = item
+	}
+	return result
+}
+
+// Difference returns a set that contains elements of s that are not in o.
+func (s *HashSet[T, H]) Difference(o *HashSet[T, H]) *HashSet[T, H] {
+	result := NewHashSet[T, H](max(0, s.Size()-o.Size()))
+	for key, item := range s.items {
+		if _, exists := o.items[key]; !exists {
+			result.items[key] = item
+		}
+	}
+	return result
+}
+
+// Intersect returns a set that contains elements that are present in both s and o.
+func (s *HashSet[T, H]) Intersect(o *HashSet[T, H]) *HashSet[T, H] {
+	result := NewHashSet[T, H](0)
+	big, small := s, o
+	if s.Size() < o.Size() {
+		big, small = o, s
+	}
+	for _, item := range small.items {
+		if big.Contains(item) {
+			result.Insert(item)
+		}
+	}
+	return result
+}
+
+// Copy creates a copy of s.
+func (s *HashSet[T, H]) Copy() *HashSet[T, H] {
+	result := NewHashSet[T, H](s.Size())
+	for key, item := range s.items {
+		result.items[key] = item
+	}
+	return result
+}
+
+// List creates a copy of s as a slice.
+func (s *HashSet[T, H]) List() []T {
+	result := make([]T, 0, s.Size())
+	for _, item := range s.items {
+		result = append(result, item)
+	}
+	return result
+}
+
+// String creates a string representation of s, using f to transform each element
+// into a string. The result contains elements sorted by their string order.
+func (s *HashSet[T, H]) String(f func(element T) string) string {
+	l := make([]string, 0, s.Size())
+	for _, item := range s.items {
+		l = append(l, f(item))
+	}
+	sort.Strings(l)
+	return fmt.Sprintf("%s", l)
+}
+
+// Equal returns whether s and o contain the same elements.
+func (s *HashSet[T, H]) Equal(o *HashSet[T, H]) bool {
+	if len(s.items) != len(o.items) {
+		return false
+	}
+	for _, item := range s.items {
+		if !o.Contains(item) {
+			return false
+		}
+	}
+	return true
+}
+
+// EqualSlice returns whether s and items contain the same elements.
+//
+// If items contains duplicates EqualSlice will return false; it is
+// assumed that items is itself set-like. For comparing equality with
+// a slice that may contain duplicates, use ContainsSlice.
+func (s *HashSet[T, H]) EqualSlice(items []T) bool {
+	if len(s.items) != len(items) {
+		return false
+	}
+	return s.ContainsAll(items)
+}

--- a/hashset_test.go
+++ b/hashset_test.go
@@ -1,0 +1,519 @@
+package set
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/shoenig/test/must"
+)
+
+// company is an example type that is not comparable, and implements Hash() string
+type company struct {
+	_       func() // not comparable
+	address string
+	floor   int
+}
+
+func (c *company) Hash() string {
+	return fmt.Sprintf("%s:%d", c.address, c.floor)
+}
+
+var (
+	c1  = &company{address: "street", floor: 1}
+	c2  = &company{address: "street", floor: 2}
+	c3  = &company{address: "street", floor: 3}
+	c4  = &company{address: "street", floor: 4}
+	c5  = &company{address: "street", floor: 5}
+	c6  = &company{address: "street", floor: 6}
+	c7  = &company{address: "street", floor: 7}
+	c8  = &company{address: "street", floor: 8}
+	c10 = &company{address: "street", floor: 10}
+)
+
+// coded is an example type that maintains its own hash code, implementing Hash() int
+type coded struct {
+	i int // internal hash code
+}
+
+func (c *coded) Hash() int {
+	return c.i
+}
+
+var (
+	s1 = &coded{i: 1}
+	s2 = &coded{i: 2}
+	s3 = &coded{i: 3}
+)
+
+func TestHashSet_New(t *testing.T) {
+	t.Run("positive", func(t *testing.T) {
+		s := NewHashSet[*company, string](1)
+		must.MapEmpty(t, s.items)
+	})
+
+	t.Run("zero", func(t *testing.T) {
+		s := NewHashSet[*company, string](0)
+		must.MapEmpty(t, s.items)
+	})
+
+	t.Run("negative", func(t *testing.T) {
+		s := NewHashSet[*company, string](-1)
+		must.MapEmpty(t, s.items)
+	})
+}
+
+func TestHashSet_Insert(t *testing.T) {
+	t.Run("one", func(t *testing.T) {
+		s := NewHashSet[*company, string](1)
+		must.True(t, s.Insert(c1))
+		must.MapContainsKeys(t, s.items, []string{"street:1"})
+	})
+
+	t.Run("re-insert", func(t *testing.T) {
+		s := NewHashSet[*company, string](1)
+		must.True(t, s.Insert(c1))
+		must.False(t, s.Insert(c1))
+		must.MapContainsKeys(t, s.items, []string{"street:1"})
+	})
+
+	t.Run("insert several", func(t *testing.T) {
+		s := NewHashSet[*company, string](3)
+		must.True(t, s.Insert(c1))
+		must.True(t, s.Insert(c2))
+		must.True(t, s.Insert(c3))
+		must.MapContainsKeys(t, s.items, []string{
+			"street:1", "street:2", "street:3",
+		})
+	})
+}
+
+func TestHashSet_InsertAll(t *testing.T) {
+	t.Run("insert none", func(t *testing.T) {
+		empty := NewHashSet[*company, string](0)
+		must.False(t, empty.InsertAll(nil))
+		must.MapEmpty(t, empty.items)
+	})
+
+	t.Run("insert some", func(t *testing.T) {
+		s := NewHashSet[*company, string](0)
+		must.True(t, s.InsertAll([]*company{c1, c2, c3}))
+		must.MapContainsKeys(t, s.items, []string{
+			"street:1", "street:2", "street:3",
+		})
+	})
+}
+
+func TestHashSet_InsertSet(t *testing.T) {
+	t.Run("insert empty", func(t *testing.T) {
+		a := HashSetFrom[*company, string]([]*company{c1, c2, c3})
+		b := NewHashSet[*company, string](0)
+		must.False(t, a.InsertSet(b))
+		must.MapContainsKeys(t, a.items, []string{
+			"street:1", "street:2", "street:3",
+		})
+	})
+
+	t.Run("insert some", func(t *testing.T) {
+		a := HashSetFrom[*company, string]([]*company{c1, c2, c3})
+		b := HashSetFrom[*company, string]([]*company{c3, c4, c5})
+		a.InsertSet(b)
+		must.MapContainsKeys(t, a.items, []string{
+			"street:1", "street:2", "street:3", "street:4", "street:5",
+		})
+	})
+}
+
+func TestHashSet_Remove(t *testing.T) {
+	t.Run("empty remove item", func(t *testing.T) {
+		s := NewHashSet[*company, string](10)
+		must.False(t, s.Remove(c1))
+		must.MapEmpty(t, s.items)
+	})
+
+	t.Run("set remove item", func(t *testing.T) {
+		s := HashSetFrom[*company, string]([]*company{c1, c2, c3})
+		must.True(t, s.Remove(c2))
+		must.MapContainsKeys(t, s.items, []string{
+			"street:1", "street:3",
+		})
+	})
+
+	t.Run("set remove missing", func(t *testing.T) {
+		s := HashSetFrom[*company, string]([]*company{c1, c2, c3})
+		must.False(t, s.Remove(c4))
+		must.MapContainsKeys(t, s.items, []string{
+			"street:1", "street:2", "street:3",
+		})
+	})
+}
+
+func TestHashSet_RemoveAll(t *testing.T) {
+	t.Run("empty remove all", func(t *testing.T) {
+		s := NewHashSet[*company, string](0)
+		must.False(t, s.RemoveAll([]*company{c1, c2, c3}))
+		must.MapEmpty(t, s.items)
+	})
+
+	t.Run("set remove nothing", func(t *testing.T) {
+		s := HashSetFrom[*company, string]([]*company{c1, c2, c3})
+		must.False(t, s.RemoveAll([]*company{c4, c5}))
+		must.MapContainsKeys(t, s.items, []string{
+			"street:1", "street:2", "street:3",
+		})
+	})
+
+	t.Run("set remove some", func(t *testing.T) {
+		s := HashSetFrom[*company, string]([]*company{c1, c2, c3, c4, c5})
+		must.True(t, s.RemoveAll([]*company{c4, c2}))
+		must.MapContainsKeys(t, s.items, []string{
+			"street:1", "street:3", "street:5",
+		})
+	})
+}
+
+func TestHashSet_RemoveSet(t *testing.T) {
+	t.Run("empty remove empty", func(t *testing.T) {
+		a := NewHashSet[*company, string](0)
+		b := NewHashSet[*company, string](0)
+		must.False(t, a.RemoveSet(b))
+		must.MapEmpty(t, a.items)
+	})
+
+	t.Run("empty remove some", func(t *testing.T) {
+		a := NewHashSet[*company, string](0)
+		b := HashSetFrom[*company, string]([]*company{c1, c2, c3})
+		must.False(t, a.RemoveSet(b))
+		must.MapEmpty(t, a.items)
+	})
+
+	t.Run("set remove some", func(t *testing.T) {
+		a := HashSetFrom[*company, string]([]*company{c1, c2, c3, c4, c5})
+		b := HashSetFrom[*company, string]([]*company{c2, c3})
+		must.True(t, a.RemoveSet(b))
+		must.MapContainsKeys(t, a.items, []string{
+			"street:1", "street:4", "street:5",
+		})
+	})
+}
+
+func TestHashSet_Contains(t *testing.T) {
+	t.Run("empty contains", func(t *testing.T) {
+		a := NewHashSet[*company, string](0)
+		must.False(t, a.Contains(c1))
+	})
+
+	t.Run("not contains", func(t *testing.T) {
+		s := HashSetFrom[*company, string]([]*company{c1, c2, c3})
+		must.False(t, s.Contains(c4))
+	})
+
+	t.Run("does contain", func(t *testing.T) {
+		s := HashSetFrom[*company, string]([]*company{c1, c2, c3})
+		must.True(t, s.Contains(c1))
+	})
+}
+
+func TestHashSet_ContainsAll(t *testing.T) {
+	t.Run("contains subset", func(t *testing.T) {
+		s := HashSetFrom[*company, string]([]*company{c1, c2, c3, c4, c5})
+		must.True(t, s.ContainsAll([]*company{c2, c3, c4}))
+	})
+
+	t.Run("contains missing", func(t *testing.T) {
+		s := HashSetFrom[*company, string]([]*company{c1, c3})
+		must.False(t, s.ContainsAll([]*company{c1, c2, c3}))
+	})
+}
+
+func TestHashSet_ContainsSlice(t *testing.T) {
+	t.Run("empty empty", func(t *testing.T) {
+		a := NewHashSet[*company, string](0)
+		b := make([]*company, 0)
+		must.True(t, a.ContainsSlice(b))
+	})
+
+	t.Run("empty some", func(t *testing.T) {
+		a := NewHashSet[*company, string](0)
+		b := []*company{c1, c2, c3}
+		must.False(t, a.ContainsSlice(b))
+	})
+
+	t.Run("some empty", func(t *testing.T) {
+		a := HashSetFrom[*company, string]([]*company{c1, c2, c3})
+		b := make([]*company, 0)
+		must.False(t, a.ContainsSlice(b))
+	})
+
+	t.Run("equal", func(t *testing.T) {
+		a := HashSetFrom[*company, string]([]*company{c1, c2, c3})
+		b := []*company{c3, c2, c1}
+		must.True(t, a.ContainsSlice(b))
+	})
+
+	t.Run("not equal", func(t *testing.T) {
+		a := HashSetFrom[*company, string]([]*company{c1, c2, c3})
+		b := []*company{c2, c3, c4}
+		must.False(t, a.ContainsSlice(b))
+	})
+
+	t.Run("subset", func(t *testing.T) {
+		a := HashSetFrom[*company, string]([]*company{c1, c2, c3, c4, c5})
+		b := []*company{c2, c3, c4}
+		must.False(t, a.ContainsSlice(b))
+	})
+
+	t.Run("superset", func(t *testing.T) {
+		a := HashSetFrom[*company, string]([]*company{c2, c3, c4})
+		b := []*company{c1, c2, c3, c4, c5}
+		must.False(t, a.ContainsSlice(b))
+	})
+
+	t.Run("duplicates", func(t *testing.T) {
+		a := HashSetFrom[*company, string]([]*company{c1, c2, c3, c4, c5})
+		b := []*company{c1, c2, c2, c3, c3, c4, c5}
+		must.True(t, a.ContainsSlice(b))
+	})
+}
+
+func TestHashSet_Subset(t *testing.T) {
+	t.Run("empty empty", func(t *testing.T) {
+		a := NewHashSet[*company, string](0)
+		b := NewHashSet[*company, string](0)
+		must.True(t, a.Subset(b))
+	})
+
+	t.Run("empty some", func(t *testing.T) {
+		a := NewHashSet[*company, string](0)
+		b := HashSetFrom[*company, string]([]*company{c1, c2, c3})
+		must.False(t, a.Subset(b))
+	})
+
+	t.Run("some empty", func(t *testing.T) {
+		a := HashSetFrom[*company, string]([]*company{c1, c2, c3})
+		b := NewHashSet[*company, string](0)
+		must.True(t, a.Subset(b))
+	})
+
+	t.Run("equal", func(t *testing.T) {
+		a := HashSetFrom[*company, string]([]*company{c1, c2, c3})
+		b := HashSetFrom[*company, string]([]*company{c2, c3, c1})
+		must.True(t, a.Subset(b))
+	})
+
+	t.Run("subset", func(t *testing.T) {
+		a := HashSetFrom[*company, string]([]*company{c1, c2, c3})
+		b := HashSetFrom[*company, string]([]*company{c3, c1})
+		must.True(t, a.Subset(b))
+	})
+
+	t.Run("superset", func(t *testing.T) {
+		a := HashSetFrom[*company, string]([]*company{c1, c2, c3})
+		b := HashSetFrom[*company, string]([]*company{c3, c1, c2, c4})
+		must.False(t, a.Subset(b))
+	})
+}
+
+func TestHashSet_Size(t *testing.T) {
+	t.Run("size empty", func(t *testing.T) {
+		s := NewHashSet[*company, string](10)
+		must.Zero(t, s.Size())
+	})
+
+	t.Run("size not empty", func(t *testing.T) {
+		s := NewHashSet[*company, string](10)
+		must.True(t, s.Insert(c1))
+		must.True(t, s.Insert(c2))
+		must.Eq(t, 2, s.Size())
+	})
+}
+
+func TestHashSet_Difference(t *testing.T) {
+	t.Run("empty \\ empty", func(t *testing.T) {
+		a := NewHashSet[*company, string](10)
+		b := NewHashSet[*company, string](10)
+		diff := a.Difference(b)
+		must.MapEmpty(t, diff.items)
+	})
+
+	t.Run("empty \\ set", func(t *testing.T) {
+		a := NewHashSet[*company, string](10)
+		b := HashSetFrom[*company, string]([]*company{c1, c2, c3, c4, c5})
+		diff := a.Difference(b)
+		must.MapEmpty(t, diff.items)
+	})
+
+	t.Run("set \\ empty", func(t *testing.T) {
+		a := HashSetFrom[*company, string]([]*company{c1, c2, c3, c4, c5})
+		b := NewHashSet[*company, string](10)
+		diff := a.Difference(b)
+		must.MapContainsKeys(t, diff.items, []string{
+			"street:1", "street:2", "street:3", "street:4", "street:5",
+		})
+	})
+
+	t.Run("set \\ other", func(t *testing.T) {
+		a := HashSetFrom[*company, string]([]*company{c1, c2, c3, c4, c5, c6, c7, c8})
+		b := HashSetFrom[*company, string]([]*company{c2, c4, c6, c8, c10, c10})
+		diff := a.Difference(b)
+		must.MapContainsKeys(t, diff.items, []string{
+			"street:1", "street:3", "street:5", "street:7",
+		})
+	})
+}
+
+func TestHashSet_Intersect(t *testing.T) {
+	t.Run("empty ∩ empty", func(t *testing.T) {
+		a := NewHashSet[*company, string](10)
+		b := NewHashSet[*company, string](10)
+		intersect := a.Intersect(b)
+		must.MapEmpty(t, intersect.items)
+	})
+
+	t.Run("set ∩ empty", func(t *testing.T) {
+		a := HashSetFrom[*company, string]([]*company{c1, c2, c3})
+		b := NewHashSet[*company, string](10)
+		intersect := a.Intersect(b)
+		must.MapEmpty(t, intersect.items)
+	})
+
+	t.Run("empty ∩ set", func(t *testing.T) {
+		a := NewHashSet[*company, string](10)
+		b := HashSetFrom[*company, string]([]*company{c1, c2, c3})
+		intersect := a.Intersect(b)
+		must.MapEmpty(t, intersect.items)
+	})
+
+	t.Run("big ∩ small", func(t *testing.T) {
+		a := HashSetFrom[*company, string]([]*company{c2, c3, c4, c6, c8})
+		b := HashSetFrom[*company, string]([]*company{c4, c5, c6, c7})
+		intersect := a.Intersect(b)
+		must.MapContainsKeys(t, intersect.items, []string{
+			"street:4", "street:6",
+		})
+	})
+
+	t.Run("small ∩ big", func(t *testing.T) {
+		a := HashSetFrom[*company, string]([]*company{c4, c5, c6, c7})
+		b := HashSetFrom[*company, string]([]*company{c2, c3, c4, c6, c8})
+		intersect := a.Intersect(b)
+		must.MapContainsKeys(t, intersect.items, []string{
+			"street:4", "street:6",
+		})
+	})
+}
+
+func TestHashSet_Copy(t *testing.T) {
+	t.Run("copy empty", func(t *testing.T) {
+		a := NewHashSet[*company, string](0)
+		b := a.Copy()
+		must.MapEmpty(t, b.items)
+		must.True(t, b.Insert(c3))
+		must.MapEmpty(t, a.items)
+		must.MapContainsKeys(t, b.items, []string{"street:3"})
+	})
+
+	t.Run("copy some", func(t *testing.T) {
+		a := HashSetFrom[*company, string]([]*company{c1, c2, c3, c4})
+		b := a.Copy()
+		must.MapContainsKeys(t, b.items, []string{
+			"street:1", "street:2", "street:3", "street:4",
+		})
+		must.True(t, b.RemoveAll([]*company{c1, c3}))
+		must.MapContainsKeys(t, b.items, []string{"street:2", "street:4"})
+		must.MapContainsKeys(t, a.items, []string{
+			"street:1", "street:2", "street:3", "street:4",
+		})
+	})
+}
+
+func TestHashSet_List(t *testing.T) {
+	t.Run("list empty", func(t *testing.T) {
+		a := NewHashSet[*company, string](10)
+		l := a.List()
+		must.Empty(t, l)
+	})
+
+	t.Run("list set", func(t *testing.T) {
+		a := HashSetFrom[*company, string]([]*company{c1, c2})
+		l := a.List()
+		must.Len(t, 2, l)
+		must.Contains(t, l, c1)
+		must.Contains(t, l, c2)
+	})
+}
+
+func TestHashSet_String(t *testing.T) {
+	t.Run("empty", func(t *testing.T) {
+		a := NewHashSet[*company, string](10)
+		s := a.String(nil)
+		must.Eq(t, "[]", s)
+	})
+
+	t.Run("some", func(t *testing.T) {
+		a := HashSetFrom[*company, string]([]*company{c1, c2})
+		s := a.String(func(c *company) string {
+			return fmt.Sprintf("(%s %d)", c.address, c.floor)
+		})
+		must.Eq(t, "[(street 1) (street 2)]", s)
+	})
+}
+
+func TestHashSet_EqualSlice(t *testing.T) {
+	t.Run("empty empty", func(t *testing.T) {
+		a := NewHashSet[*company, string](0)
+		b := make([]*company, 0)
+		must.True(t, a.EqualSlice(b))
+	})
+
+	t.Run("empty some", func(t *testing.T) {
+		a := NewHashSet[*company, string](0)
+		b := []*company{c1, c2, c3}
+		must.False(t, a.EqualSlice(b))
+	})
+
+	t.Run("some empty", func(t *testing.T) {
+		a := HashSetFrom[*company, string]([]*company{c1, c2, c3})
+		b := make([]*company, 0)
+		must.False(t, a.EqualSlice(b))
+	})
+
+	t.Run("equal", func(t *testing.T) {
+		a := HashSetFrom[*company, string]([]*company{c1, c2, c3})
+		b := []*company{c3, c2, c1}
+		must.True(t, a.EqualSlice(b))
+	})
+
+	t.Run("not equal", func(t *testing.T) {
+		a := HashSetFrom[*company, string]([]*company{c1, c2, c3})
+		b := []*company{c2, c3, c4}
+		must.False(t, a.EqualSlice(b))
+	})
+
+	t.Run("subset", func(t *testing.T) {
+		a := HashSetFrom[*company, string]([]*company{c1, c2, c3, c4, c5})
+		b := []*company{c2, c3, c4}
+		must.False(t, a.EqualSlice(b))
+	})
+
+	t.Run("superset", func(t *testing.T) {
+		a := HashSetFrom[*company, string]([]*company{c2, c3, c4})
+		b := []*company{c1, c2, c3, c4, c5}
+		must.False(t, a.EqualSlice(b))
+	})
+
+	t.Run("duplicates", func(t *testing.T) {
+		a := HashSetFrom[*company, string]([]*company{c1, c2, c3, c4, c5})
+		b := []*company{c1, c2, c2, c3, c3, c4, c5}
+		must.False(t, a.EqualSlice(b))
+	})
+}
+
+func TestHashSet_HashCode(t *testing.T) {
+	a := NewHashSet[*coded, int](0)
+	a.Insert(s1)
+	a.Insert(s2)
+	must.MapContainsKeys(t, a.items, []int{1, 2})
+	must.True(t, a.Contains(s1))
+	must.True(t, a.Contains(s2))
+	must.False(t, a.Contains(s3))
+}

--- a/set.go
+++ b/set.go
@@ -23,6 +23,9 @@ func max(a, b int) int {
 //
 // A Set will automatically grow or shrink its capacity as items are added or
 // removed.
+//
+// T must *not* be of pointer type, nor contain pointer fields, which are comparable
+// but not in the way you expect. For these types, use HashSet instead.
 func New[T comparable](size int) *Set[T] {
 	return &Set[T]{
 		items: make(map[T]nothing, max(0, size)),
@@ -30,6 +33,9 @@ func New[T comparable](size int) *Set[T] {
 }
 
 // From creates a new Set containing each item in items.
+//
+// T must *not* be of pointer type, nor contain pointer fields, which are comparable
+// but not in the way you expect. For these types, use HashSet instead.
 func From[T comparable](items []T) *Set[T] {
 	s := New[T](len(items))
 	s.InsertAll(items)
@@ -37,6 +43,9 @@ func From[T comparable](items []T) *Set[T] {
 }
 
 // FromFunc creates a new Set containing a conversion of each item in items.
+//
+// T must *not* be of pointer type, nor contain pointer fields, which are comparable
+// but not in the way you expect. For these types, use HashSet instead.
 func FromFunc[A any, T comparable](items []A, conversion func(A) T) *Set[T] {
 	s := New[T](len(items))
 	for _, item := range items {
@@ -96,7 +105,6 @@ func (s *Set[T]) Remove(item T) bool {
 	if _, exists := s.items[item]; !exists {
 		return false
 	}
-
 	delete(s.items, item)
 	return true
 }
@@ -127,7 +135,7 @@ func (s *Set[T]) RemoveSet(o *Set[T]) bool {
 	return modified
 }
 
-// Contains returns whether item is present in the set.
+// Contains returns whether item is present in s.
 func (s *Set[T]) Contains(item T) bool {
 	_, exists := s.items[item]
 	return exists
@@ -138,7 +146,6 @@ func (s *Set[T]) ContainsAll(items []T) bool {
 	if len(s.items) < len(items) {
 		return false
 	}
-
 	for _, item := range items {
 		if !s.Contains(item) {
 			return false
@@ -153,7 +160,7 @@ func (s *Set[T]) ContainsAll(items []T) bool {
 // If the slice is known to be set-like (no duplicates), EqualSlice provides
 // a more efficient implementation.
 func (s *Set[T]) ContainsSlice(items []T) bool {
-	return s.Equal(From(items))
+	return s.Equal(From[T](items))
 }
 
 // Subset returns whether o is a subset of s.
@@ -161,13 +168,11 @@ func (s *Set[T]) Subset(o *Set[T]) bool {
 	if len(s.items) < len(o.items) {
 		return false
 	}
-
 	for item := range o.items {
 		if !s.Contains(item) {
 			return false
 		}
 	}
-
 	return true
 }
 
@@ -202,12 +207,10 @@ func (s *Set[T]) Difference(o *Set[T]) *Set[T] {
 // Intersect returns a set that contains elements that are present in both s and o.
 func (s *Set[T]) Intersect(o *Set[T]) *Set[T] {
 	result := New[T](0)
-
 	big, small := s, o
 	if s.Size() < o.Size() {
 		big, small = o, s
 	}
-
 	for item := range small.items {
 		if big.Contains(item) {
 			result.Insert(item)
@@ -242,7 +245,7 @@ func (s *Set[T]) String(f func(element T) string) string {
 		l = append(l, f(item))
 	}
 	sort.Strings(l)
-	return fmt.Sprintf("%v", l)
+	return fmt.Sprintf("%s", l)
 }
 
 // Equal returns whether s and o contain the same elements.

--- a/set_test.go
+++ b/set_test.go
@@ -353,8 +353,8 @@ func TestSet_Remove(t *testing.T) {
 	})
 }
 
-func TestSet_RemoveItems(t *testing.T) {
-	t.Run("empty remove items", func(t *testing.T) {
+func TestSet_RemoveAll(t *testing.T) {
+	t.Run("empty remove all", func(t *testing.T) {
 		s := New[int](10)
 		must.False(t, s.RemoveAll([]int{1, 2, 3}))
 		must.MapEmpty(t, s.items)
@@ -381,14 +381,14 @@ func TestSet_RemoveSet(t *testing.T) {
 		must.MapEmpty(t, a.items)
 	})
 
-	t.Run("empty remove set", func(t *testing.T) {
+	t.Run("empty remove some", func(t *testing.T) {
 		a := New[int](0)
 		b := From[int]([]int{1, 2, 3, 4})
 		must.False(t, a.RemoveSet(b))
 		must.MapEmpty(t, a.items)
 	})
 
-	t.Run("set remove other", func(t *testing.T) {
+	t.Run("set remove some", func(t *testing.T) {
 		a := From[int]([]int{1, 2, 3, 4, 5, 6, 7, 8})
 		b := From[int]([]int{2, 4, 6, 8})
 		must.True(t, a.RemoveSet(b))
@@ -450,9 +450,9 @@ func TestSet_String(t *testing.T) {
 
 	t.Run("custom", func(t *testing.T) {
 		a := From[employee]([]employee{
-			employee{"mitchell", 1},
-			employee{"jack", 3},
-			employee{"armon", 2},
+			{"mitchell", 1},
+			{"jack", 3},
+			{"armon", 2},
 		})
 		s := a.String(func(e employee) string {
 			return fmt.Sprintf("(%d %s)", e.id, e.name)


### PR DESCRIPTION
This PR introduces a second Set implementation for types that implement
a Hash function.

There is the `Hash` type constraint, which can be string-like or int-like.

There is also the `HashFunc` type constraint, which is satisfied by a
type with `Hash() <Hash>` function.

A type that satisfies `HashFunc` can then be stored in a `HashSet`.

Closes #5
