### PR TITLE
sets: provide an Empty() method

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Implements the following set operations
 - ContainsAll
 - Subset
 - Size
+- Empty
 - Union
 - Difference
 - Intersect

--- a/hashset.go
+++ b/hashset.go
@@ -173,6 +173,11 @@ func (s *HashSet[T, H]) Size() int {
 	return len(s.items)
 }
 
+// Empty returns true if s contains no elements, false otherwise.
+func (s *HashSet[T, H]) Empty() bool {
+	return s.Size() == 0
+}
+
 // Union returns a set that contains all elements of s and o combined.
 func (s *HashSet[T, H]) Union(o *HashSet[T, H]) *HashSet[T, H] {
 	result := NewHashSet[T, H](s.Size())

--- a/hashset_test.go
+++ b/hashset_test.go
@@ -331,6 +331,20 @@ func TestHashSet_Size(t *testing.T) {
 	})
 }
 
+func TestHashSet_Empty(t *testing.T) {
+	t.Run("is empty", func(t *testing.T) {
+		s := NewHashSet[*company, string](10)
+		must.Empty(t, s)
+	})
+
+	t.Run("is not empty", func(t *testing.T) {
+		s := NewHashSet[*company, string](10)
+		must.True(t, s.Insert(c1))
+		must.True(t, s.Insert(c2))
+		must.NotEmpty(t, s)
+	})
+}
+
 func TestHashSet_Difference(t *testing.T) {
 	t.Run("empty \\ empty", func(t *testing.T) {
 		a := NewHashSet[*company, string](10)

--- a/set.go
+++ b/set.go
@@ -181,6 +181,11 @@ func (s *Set[T]) Size() int {
 	return len(s.items)
 }
 
+// Empty returns true if s contains no elements, false otherwise.
+func (s *Set[T]) Empty() bool {
+	return s.Size() == 0
+}
+
 // Union returns a set that contains all elements of s and o combined.
 func (s *Set[T]) Union(o *Set[T]) *Set[T] {
 	result := New[T](s.Size())

--- a/set_test.go
+++ b/set_test.go
@@ -232,6 +232,18 @@ func TestSet_Size(t *testing.T) {
 	})
 }
 
+func TestSet_Empty(t *testing.T) {
+	t.Run("is empty", func(t *testing.T) {
+		s := New[int](10)
+		must.Empty(t, s)
+	})
+
+	t.Run("is not empty", func(t *testing.T) {
+		s := From[int]([]int{1, 2, 3, 4})
+		must.NotEmpty(t, s)
+	})
+}
+
 func TestSet_Union(t *testing.T) {
 	t.Run("empty ∪ empty", func(t *testing.T) {
 		a := New[int](0)


### PR DESCRIPTION
This PR expands Set and HashSet to implement an Empty() method. The method
returns true if a set is empty, false otherwise. This will help cleanup some
lines of code where we other wise need to do something like .Size() == 0.
