### PR TITLE
breaking: fixup String() function signature

### DIFF
--- a/hashset.go
+++ b/hashset.go
@@ -241,9 +241,18 @@ func (s *HashSet[T, H]) List() []T {
 	return s.Slice()
 }
 
-// String creates a string representation of s, using f to transform each element
+// String creates a string representation of s, using "%v" printf formatting to transform
+// each element into a string. The result contains elements sorted by their lexical
+// string order.
+func (s *HashSet[T, H]) String() string {
+	return s.StringFunc(func(element T) string {
+		return fmt.Sprintf("%v", element)
+	})
+}
+
+// StringFunc creates a string representation of s, using f to transform each element
 // into a string. The result contains elements sorted by their string order.
-func (s *HashSet[T, H]) String(f func(element T) string) string {
+func (s *HashSet[T, H]) StringFunc(f func(element T) string) string {
 	l := make([]string, 0, s.Size())
 	for _, item := range s.items {
 		l = append(l, f(item))

--- a/hashset_test.go
+++ b/hashset_test.go
@@ -22,6 +22,10 @@ func (c *company) Hash() string {
 	return fmt.Sprintf("%s:%d", c.address, c.floor)
 }
 
+func (c *company) String() string {
+	return fmt.Sprintf("<%s %d>", c.address, c.floor)
+}
+
 var (
 	c1  = &company{address: "street", floor: 1}
 	c2  = &company{address: "street", floor: 2}
@@ -477,15 +481,21 @@ func TestHashSet_List(t *testing.T) {
 }
 
 func TestHashSet_String(t *testing.T) {
+	a := HashSetFrom[*company, string]([]*company{c2, c1})
+	result := a.String()
+	must.Eq(t, "[<street 1> <street 2>]", result)
+}
+
+func TestHashSet_StringFunc(t *testing.T) {
 	t.Run("empty", func(t *testing.T) {
 		a := NewHashSet[*company, string](10)
-		s := a.String(nil)
+		s := a.StringFunc(nil)
 		must.Eq(t, "[]", s)
 	})
 
 	t.Run("some", func(t *testing.T) {
 		a := HashSetFrom[*company, string]([]*company{c1, c2})
-		s := a.String(func(c *company) string {
+		s := a.StringFunc(func(c *company) string {
 			return fmt.Sprintf("(%s %d)", c.address, c.floor)
 		})
 		must.Eq(t, "[(street 1) (street 2)]", s)

--- a/set.go
+++ b/set.go
@@ -249,9 +249,18 @@ func (s *Set[T]) List() []T {
 	return s.Slice()
 }
 
-// String creates a string representation of s, using f to transform each element
-// into a string. The result contains elements sorted by their string order.
-func (s *Set[T]) String(f func(element T) string) string {
+// String creates a string representation of s, using "%v" printf formating to transform
+// each element into a string. The result contains elements sorted by their lexical
+// string order.
+func (s *Set[T]) String() string {
+	return s.StringFunc(func(element T) string {
+		return fmt.Sprintf("%v", element)
+	})
+}
+
+// StringFunc creates a string representation of s, using f to transform each element
+// into a string. The result contains elements sorted by their lexical string order.
+func (s *Set[T]) StringFunc(f func(element T) string) string {
 	l := make([]string, 0, s.Size())
 	for item := range s.items {
 		l = append(l, f(item))

--- a/set_test.go
+++ b/set_test.go
@@ -12,6 +12,10 @@ type employee struct {
 	id   int
 }
 
+func (e *employee) String() string {
+	return fmt.Sprintf("(%d %s)", e.id, e.name)
+}
+
 func TestSet_New(t *testing.T) {
 	t.Run("positive", func(t *testing.T) {
 		s := New[float64](1)
@@ -463,27 +467,41 @@ func TestSet_List(t *testing.T) {
 }
 
 func TestSet_String(t *testing.T) {
+	t.Run("ints", func(t *testing.T) {
+		a := From([]int{1, 2, 3})
+		result := a.String()
+		must.Eq(t, "[1 2 3]", result)
+	})
+
+	t.Run("custom", func(t *testing.T) {
+		a := From([]*employee{{"bob", 2}, {"alice", 1}, {"carl", 3}})
+		result := a.String()
+		must.Eq(t, "[(1 alice) (2 bob) (3 carl)]", result)
+	})
+}
+
+func TestSet_StringFunc(t *testing.T) {
 	t.Run("empty", func(t *testing.T) {
 		a := New[string](10)
-		s := a.String(nil)
+		s := a.StringFunc(nil)
 		must.Eq(t, "[]", s)
 	})
 
 	t.Run("int", func(t *testing.T) {
-		a := From[int]([]int{5, 2, 5, 1, 3})
-		s := a.String(func(i int) string {
+		a := From([]int{5, 2, 5, 1, 3})
+		s := a.StringFunc(func(i int) string {
 			return fmt.Sprintf("%d", i)
 		})
 		must.Eq(t, "[1 2 3 5]", s)
 	})
 
 	t.Run("custom", func(t *testing.T) {
-		a := From[employee]([]employee{
+		a := From([]employee{
 			{"mitchell", 1},
 			{"jack", 3},
 			{"armon", 2},
 		})
-		s := a.String(func(e employee) string {
+		s := a.StringFunc(func(e employee) string {
 			return fmt.Sprintf("(%d %s)", e.id, e.name)
 		})
 		must.Eq(t, "[(1 mitchell) (2 armon) (3 jack)]", s)


### PR DESCRIPTION
This PR renames String() to StringFunc(), and adds back String()
but with the standard signature that satisfies the fmt.Stringer
interface. Although this is a breaking change, it seems unlikely
to cause real world problems, and the benefits seem like a clear
net-win.
