### PR TITLE
refactor: rename List() to Slice()

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ for k := range m {
 
 The same result, but in one line using package `go-set`.
 ```go
-list := set.From[string](items).List()
+list := set.From[string](items).Slice()
 ```
 
 # Hash Function
@@ -67,7 +67,7 @@ Provides helper methods
 
 - Equal
 - Copy
-- List
+- Slice
 - String
 
 # Install

--- a/hashset.go
+++ b/hashset.go
@@ -225,13 +225,20 @@ func (s *HashSet[T, H]) Copy() *HashSet[T, H] {
 	return result
 }
 
-// List creates a copy of s as a slice.
-func (s *HashSet[T, H]) List() []T {
+// Slice creates a copy of s as a slice.
+func (s *HashSet[T, H]) Slice() []T {
 	result := make([]T, 0, s.Size())
 	for _, item := range s.items {
 		result = append(result, item)
 	}
 	return result
+}
+
+// List creates a copy of s as a slice.
+//
+// Deprecated: use Slice() instead.
+func (s *HashSet[T, H]) List() []T {
+	return s.Slice()
 }
 
 // String creates a string representation of s, using f to transform each element

--- a/hashset_test.go
+++ b/hashset_test.go
@@ -444,6 +444,22 @@ func TestHashSet_Copy(t *testing.T) {
 	})
 }
 
+func TestHashSet_Slice(t *testing.T) {
+	t.Run("slice empty", func(t *testing.T) {
+		a := NewHashSet[*company, string](10)
+		l := a.Slice()
+		must.SliceEmpty(t, l)
+	})
+
+	t.Run("slice set", func(t *testing.T) {
+		a := HashSetFrom[*company, string]([]*company{c1, c2})
+		l := a.Slice()
+		must.Len(t, 2, l)
+		must.SliceContainsEqual(t, l, c1)
+		must.SliceContainsEqual(t, l, c2)
+	})
+}
+
 func TestHashSet_List(t *testing.T) {
 	t.Run("list empty", func(t *testing.T) {
 		a := NewHashSet[*company, string](10)
@@ -454,9 +470,9 @@ func TestHashSet_List(t *testing.T) {
 	t.Run("list set", func(t *testing.T) {
 		a := HashSetFrom[*company, string]([]*company{c1, c2})
 		l := a.List()
-		must.Len[*company](t, 2, l)
-		must.SliceContainsEqual[*company](t, l, c1)
-		must.SliceContainsEqual[*company](t, l, c2)
+		must.Len(t, 2, l)
+		must.SliceContainsEqual(t, l, c1)
+		must.SliceContainsEqual(t, l, c2)
 	})
 }
 

--- a/set.go
+++ b/set.go
@@ -233,13 +233,20 @@ func (s *Set[T]) Copy() *Set[T] {
 	return result
 }
 
-// List creates a copy of s as a slice.
-func (s *Set[T]) List() []T {
+// Slice creates a copy of s as a slice. Elements are in no particular order.
+func (s *Set[T]) Slice() []T {
 	result := make([]T, 0, s.Size())
 	for item := range s.items {
 		result = append(result, item)
 	}
 	return result
+}
+
+// List creates a copy of s as a slice.
+//
+// Deprecated: use Slice() instead.
+func (s *Set[T]) List() []T {
+	return s.Slice()
 }
 
 // String creates a string representation of s, using f to transform each element

--- a/set_test.go
+++ b/set_test.go
@@ -428,6 +428,23 @@ func TestSet_Copy(t *testing.T) {
 	})
 }
 
+func TestSet_Slice(t *testing.T) {
+	t.Run("slice empty", func(t *testing.T) {
+		a := New[string](10)
+		l := a.Slice()
+		must.SliceEmpty(t, l)
+	})
+
+	t.Run("slice set", func(t *testing.T) {
+		a := From([]string{"apple", "banana", "cherry"})
+		l := a.Slice()
+		must.Len(t, 3, l)
+		must.SliceContains(t, l, "apple")
+		must.SliceContains(t, l, "banana")
+		must.SliceContains(t, l, "cherry")
+	})
+}
+
 func TestSet_List(t *testing.T) {
 	t.Run("list empty", func(t *testing.T) {
 		a := New[string](10)
@@ -436,7 +453,7 @@ func TestSet_List(t *testing.T) {
 	})
 
 	t.Run("list set", func(t *testing.T) {
-		a := From[string]([]string{"apple", "banana", "cherry"})
+		a := From([]string{"apple", "banana", "cherry"})
 		l := a.List()
 		must.Len(t, 3, l)
 		must.SliceContains(t, l, "apple")


### PR DESCRIPTION
This PR renames List() to Slice(), and marks the old function as
deprecated. This helps keep with Go naming conventions.
