### PR TITLE
hashset: provide HashString() and HashParts() helper functions

### DIFF
--- a/hashset.go
+++ b/hashset.go
@@ -26,6 +26,41 @@ type HashSet[T HashFunc[H], H Hash] struct {
 	items map[H]T
 }
 
+// Hash64 represents an acceptable output type of included hashing helper functions.
+type Hash64 interface {
+	~int | ~uint | ~int64 | ~uint64
+}
+
+// HashString computes a hash of s.
+//
+// Implementation is based on djb2a.
+//
+// http://www.cse.yorku.ca/~oz/hash.html
+//
+// Not a cryptographic hash.
+func HashString[H Hash64](s string) H {
+	var hash H = 5381
+	for _, c := range s {
+		hash = hash*33 ^ H(c)
+	}
+	return hash
+}
+
+// HashParts combines parts into a hash.
+//
+// Implementation is based on djb2a.
+//
+// http://www.cse.yorku.ca/~oz/hash.html
+//
+// Not a cryptographic hash.
+func HashParts[H Hash64](parts ...H) H {
+	var hash H = 5381
+	for _, part := range parts {
+		hash = hash*33 ^ part
+	}
+	return hash
+}
+
 // NewHashSet creates a HashSet with underlying capacity of size.
 //
 // A HashSet will automatically grow or shrink its capacity as items are added

--- a/hashset_test.go
+++ b/hashset_test.go
@@ -602,3 +602,37 @@ func TestHashSet_HashCode(t *testing.T) {
 	must.True(t, a.Contains(s2))
 	must.False(t, a.Contains(s3))
 }
+
+func TestHashString(t *testing.T) {
+	cases := []struct {
+		input string
+		exp   int
+	}{
+		{input: "", exp: 5381},
+		{input: "a", exp: 177604},
+		{input: "b", exp: 177607},
+		{input: "ab", exp: 5860902},
+	}
+
+	for _, tc := range cases {
+		result := HashString[int](tc.input)
+		must.Eq(t, tc.exp, result)
+	}
+}
+
+func TestHashParts(t *testing.T) {
+	cases := []struct {
+		input []int
+		exp   int
+	}{
+		{input: nil, exp: 5381},
+		{input: []int{97}, exp: 177604},
+		{input: []int{98}, exp: 177607},
+		{input: []int{97, 98}, exp: 5860902},
+	}
+
+	for _, tc := range cases {
+		result := HashParts(tc.input...)
+		must.Eq(t, tc.exp, result)
+	}
+}


### PR DESCRIPTION
This PR adds HashString(string) and HashParts(<number>) helper functions
for computing usable hash values for implementing Hash() functions of
complex struct types.

e.g.

type S struct {
  A int
  B string
}

func (s *S) Hash() int {
  return set.HashParts(
    s.A,
    set.HashString(B),
  )
}
