### PR TITLE
sets: rename All funcs as Slice funcs

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,14 +49,15 @@ to implement an efficient hash function using a hash code based on prime multipl
 Implements the following set operations
 
 - Insert
-- InsertAll
+- InsertSlice
 - InsertSet
 - Remove
-- RemoveAll
+- RemoveSlice
 - RemoveSet
 - RemoveFunc
 - Contains
 - ContainsAll
+- ContainsSlice
 - Subset
 - Size
 - Empty

--- a/hashset.go
+++ b/hashset.go
@@ -45,7 +45,7 @@ func NewHashSet[T HashFunc[H], H Hash](size int) *HashSet[T, H] {
 // that include non-comparable fields to provide their own hash algorithm.
 func HashSetFrom[T HashFunc[H], H Hash](items []T) *HashSet[T, H] {
 	s := NewHashSet[T, H](len(items))
-	s.InsertAll(items)
+	s.InsertSlice(items)
 	return s
 }
 
@@ -64,7 +64,16 @@ func (s *HashSet[T, H]) Insert(item T) bool {
 // InsertAll will insert each item in items into s.
 //
 // Return true if s was modified (at least one item was not already in s), false otherwise.
+//
+// Deprecated: use InsertSlice instead.
 func (s *HashSet[T, H]) InsertAll(items []T) bool {
+	return s.InsertSlice(items)
+}
+
+// InsertSlice will insert each item in items into s.
+//
+// Return true if s was modified (at least one item was not already in s), false otherwise.
+func (s *HashSet[T, H]) InsertSlice(items []T) bool {
 	modified := false
 	for _, item := range items {
 		if s.Insert(item) {
@@ -103,7 +112,16 @@ func (s *HashSet[T, H]) Remove(item T) bool {
 // RemoveAll will remove each item in items from s.
 //
 // Return true if s was modified (any item was present), false otherwise.
+//
+// Deprecated: use RemoveSlice instead.
 func (s *HashSet[T, H]) RemoveAll(items []T) bool {
+	return s.RemoveSlice(items)
+}
+
+// RemoveSlice will remove each item in items from s.
+//
+// Return true if s was modified (any item was present), false otherwise.
+func (s *HashSet[T, H]) RemoveSlice(items []T) bool {
 	modified := false
 	for _, item := range items {
 		if s.Remove(item) {

--- a/hashset_test.go
+++ b/hashset_test.go
@@ -95,16 +95,16 @@ func TestHashSet_Insert(t *testing.T) {
 	})
 }
 
-func TestHashSet_InsertAll(t *testing.T) {
+func TestHashSet_InsertSlice(t *testing.T) {
 	t.Run("insert none", func(t *testing.T) {
 		empty := NewHashSet[*company, string](0)
-		must.False(t, empty.InsertAll(nil))
+		must.False(t, empty.InsertSlice(nil))
 		must.MapEmpty(t, empty.items)
 	})
 
 	t.Run("insert some", func(t *testing.T) {
 		s := NewHashSet[*company, string](0)
-		must.True(t, s.InsertAll([]*company{c1, c2, c3}))
+		must.True(t, s.InsertSlice([]*company{c1, c2, c3}))
 		must.MapContainsKeys(t, s.items, []string{
 			"street:1", "street:2", "street:3",
 		})
@@ -155,16 +155,16 @@ func TestHashSet_Remove(t *testing.T) {
 	})
 }
 
-func TestHashSet_RemoveAll(t *testing.T) {
+func TestHashSet_RemoveSlice(t *testing.T) {
 	t.Run("empty remove all", func(t *testing.T) {
 		s := NewHashSet[*company, string](0)
-		must.False(t, s.RemoveAll([]*company{c1, c2, c3}))
+		must.False(t, s.RemoveSlice([]*company{c1, c2, c3}))
 		must.MapEmpty(t, s.items)
 	})
 
 	t.Run("set remove nothing", func(t *testing.T) {
 		s := HashSetFrom[*company, string]([]*company{c1, c2, c3})
-		must.False(t, s.RemoveAll([]*company{c4, c5}))
+		must.False(t, s.RemoveSlice([]*company{c4, c5}))
 		must.MapContainsKeys(t, s.items, []string{
 			"street:1", "street:2", "street:3",
 		})
@@ -172,7 +172,7 @@ func TestHashSet_RemoveAll(t *testing.T) {
 
 	t.Run("set remove some", func(t *testing.T) {
 		s := HashSetFrom[*company, string]([]*company{c1, c2, c3, c4, c5})
-		must.True(t, s.RemoveAll([]*company{c4, c2}))
+		must.True(t, s.RemoveSlice([]*company{c4, c2}))
 		must.MapContainsKeys(t, s.items, []string{
 			"street:1", "street:3", "street:5",
 		})

--- a/set.go
+++ b/set.go
@@ -38,7 +38,7 @@ func New[T comparable](size int) *Set[T] {
 // but not in the way you expect. For these types, use HashSet instead.
 func From[T comparable](items []T) *Set[T] {
 	s := New[T](len(items))
-	s.InsertAll(items)
+	s.InsertSlice(items)
 	return s
 }
 
@@ -75,7 +75,16 @@ func (s *Set[T]) Insert(item T) bool {
 // InsertAll will insert each item in items into s.
 //
 // Return true if s was modified (at least one item was not already in s), false otherwise.
+//
+// Deprecated: use InsertSlice instead.
 func (s *Set[T]) InsertAll(items []T) bool {
+	return s.InsertSlice(items)
+}
+
+// InsertSlice will insert each item in items into s.
+//
+// Return true if s was modified (at least one item was not already in s), false otherwise.
+func (s *Set[T]) InsertSlice(items []T) bool {
 	modified := false
 	for _, item := range items {
 		if s.Insert(item) {
@@ -112,7 +121,16 @@ func (s *Set[T]) Remove(item T) bool {
 // RemoveAll will remove each item in items from s.
 //
 // Return true if s was modified (any item was present), false otherwise.
+//
+// Deprecated: use RemoveSlice instead.
 func (s *Set[T]) RemoveAll(items []T) bool {
+	return s.RemoveSlice(items)
+}
+
+// RemoveSlice will remove each item in items from s.
+//
+// Return true if s was modified (any item was present), false otherwise.
+func (s *Set[T]) RemoveSlice(items []T) bool {
 	modified := false
 	for _, item := range items {
 		if s.Remove(item) {

--- a/set_test.go
+++ b/set_test.go
@@ -99,23 +99,23 @@ func TestSet_Insert(t *testing.T) {
 	})
 }
 
-func TestSet_InsertAll(t *testing.T) {
+func TestSet_InsertSlice(t *testing.T) {
 	t.Run("insert none", func(t *testing.T) {
 		empty := New[int](0)
-		must.False(t, empty.InsertAll(nil))
+		must.False(t, empty.InsertSlice(nil))
 		must.MapEmpty(t, empty.items)
 	})
 
 	t.Run("insert some", func(t *testing.T) {
 		s := New[string](0)
-		must.True(t, s.InsertAll([]string{"apple", "banana", "cherry"}))
+		must.True(t, s.InsertSlice([]string{"apple", "banana", "cherry"}))
 		must.MapContainsKeys(t, s.items, []string{"apple", "banana", "cherry"})
 	})
 
 	t.Run("insert duplicates", func(t *testing.T) {
 		s := New[int](0)
-		must.True(t, s.InsertAll([]int{2, 4, 6, 8}))
-		must.True(t, s.InsertAll([]int{4, 5, 6}))
+		must.True(t, s.InsertSlice([]int{2, 4, 6, 8}))
+		must.True(t, s.InsertSlice([]int{4, 5, 6}))
 		must.MapContainsKeys(t, s.items, []int{2, 4, 5, 6, 8})
 	})
 }
@@ -369,22 +369,22 @@ func TestSet_Remove(t *testing.T) {
 	})
 }
 
-func TestSet_RemoveAll(t *testing.T) {
+func TestSet_RemoveSlice(t *testing.T) {
 	t.Run("empty remove all", func(t *testing.T) {
 		s := New[int](10)
-		must.False(t, s.RemoveAll([]int{1, 2, 3}))
+		must.False(t, s.RemoveSlice([]int{1, 2, 3}))
 		must.MapEmpty(t, s.items)
 	})
 
 	t.Run("set remove nothing", func(t *testing.T) {
 		s := From[int]([]int{1, 2, 3})
-		must.False(t, s.RemoveAll(nil))
+		must.False(t, s.RemoveSlice(nil))
 		must.MapContainsKeys(t, s.items, []int{1, 2, 3})
 	})
 
 	t.Run("set remove some", func(t *testing.T) {
 		s := From[int]([]int{1, 2, 3, 4, 5, 6})
-		must.True(t, s.RemoveAll([]int{5, 6, 7, 8, 9}))
+		must.True(t, s.RemoveSlice([]int{5, 6, 7, 8, 9}))
 		must.MapContainsKeys(t, s.items, []int{1, 2, 3, 4})
 	})
 }


### PR DESCRIPTION
This PR deprecates `InsertAll()` and `RemoveAll()`, renaming them as `InsertSlice()`
and `RemoveSlice()` to be more clear and consistent with other things.
