### PR TITLE
sets: add TreeSet type for orderable data

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,6 +2,7 @@ name: Run CI Tests
 on: [push]
 jobs:
   run-tests:
+    timeout-minutes: 10
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3

--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -1,0 +1,185 @@
+package set
+
+import (
+	"math/rand"
+	"sort"
+	"testing"
+)
+
+type test struct {
+	size int
+	name string
+}
+
+var cases []test = []test{
+	{size: 10, name: "10"},
+	{size: 1_000, name: "1000"},
+	{size: 100_000, name: "100000"},
+	{size: 1_000_000, name: "1000000"},
+}
+
+func random[I ~int](n int) []I {
+	result := make([]I, n)
+	for i := 0; i < n; i++ {
+		result[i] = I(rand.Int())
+	}
+	return result
+}
+
+func unsort[I ~int](s []I) {
+	s[0], s[len(s)-1] = s[len(s)-1], s[0]
+}
+
+type hashint int
+
+func (i hashint) Hash() int {
+	return int(i)
+}
+
+func BenchmarkSlice_Insert(b *testing.B) {
+	for _, tc := range cases {
+		s := random[int](tc.size)
+		b.Run(tc.name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				s = append(s, i)
+			}
+		})
+	}
+}
+
+func BenchmarkSet_Insert(b *testing.B) {
+	for _, tc := range cases {
+		s := From(random[int](tc.size))
+		b.Run(tc.name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				s.Insert(i)
+			}
+		})
+	}
+}
+
+func BenchmarkHashSet_Insert(b *testing.B) {
+	for _, tc := range cases {
+		hs := HashSetFrom[hashint, int](random[hashint](tc.size))
+		b.Run(tc.name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				hs.Insert(hashint(i))
+			}
+		})
+	}
+}
+
+func BenchmarkTreeSet_Insert(b *testing.B) {
+	for _, tc := range cases {
+		ts := TreeSetFrom[int, Compare[int]](random[int](tc.size), Cmp[int])
+		b.Run(tc.name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				ts.Insert(i)
+			}
+		})
+	}
+}
+
+func BenchmarkSlice_Minimum(b *testing.B) {
+	for _, tc := range cases {
+		slice := random[int](tc.size)
+		b.Run(tc.name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				sort.Ints(slice)
+				_ = slice[0]
+				unsort(slice)
+			}
+		})
+	}
+}
+
+func BenchmarkSet_Minimum(b *testing.B) {
+	for _, tc := range cases {
+		s := From(random[int](tc.size))
+		b.Run(tc.name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				values := s.Slice()
+				sort.Ints(values)
+				_ = values[0]
+			}
+		})
+	}
+}
+
+func BenchmarkHashSet_Minimum(b *testing.B) {
+	for _, tc := range cases {
+		hs := HashSetFrom[hashint, int](random[hashint](tc.size))
+		b.Run(tc.name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				values := hs.Slice()
+				sort.Slice(values, func(a, b int) bool { return values[a] < values[b] })
+				_ = values[0]
+				unsort(values)
+			}
+		})
+	}
+}
+
+func BenchmarkTreeSet_Minimum(b *testing.B) {
+	for _, tc := range cases {
+		ts := TreeSetFrom[int, Compare[int]](random[int](tc.size), Cmp[int])
+		b.Run(tc.name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = ts.Min()
+			}
+		})
+	}
+}
+
+func BenchmarkSlice_Contains(b *testing.B) {
+	contains := func(s []int, target int) bool {
+		for i := 0; i < len(s); i++ {
+			if s[i] == target {
+				return true
+			}
+		}
+		return false
+	}
+
+	for _, tc := range cases {
+		slice := random[int](tc.size)
+		b.Run(tc.name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = contains(slice, i)
+			}
+		})
+	}
+}
+
+func BenchmarkSet_Contains(b *testing.B) {
+	for _, tc := range cases {
+		s := From(random[int](tc.size))
+		b.Run(tc.name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = s.Contains(i)
+			}
+		})
+	}
+}
+
+func BenchmarkHashSet_Contains(b *testing.B) {
+	for _, tc := range cases {
+		hs := HashSetFrom[hashint, int](random[hashint](tc.size))
+		b.Run(tc.name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = hs.Contains(hashint(i))
+			}
+		})
+	}
+}
+
+func BenchmarkTreeSet_Contains(b *testing.B) {
+	for _, tc := range cases {
+		ts := TreeSetFrom[int, Compare[int]](random[int](tc.size), Cmp[int])
+		b.Run(tc.name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = ts.Contains(i)
+			}
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,6 @@ module github.com/hashicorp/go-set
 
 go 1.18
 
-require github.com/shoenig/test v0.6.2
+require github.com/shoenig/test v0.6.3
 
 require github.com/google/go-cmp v0.5.9 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,4 @@
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
-github.com/shoenig/test v0.6.2 h1:tdq+WGnznwE5xcOMXkqqXuudK75RkSGBazBGcP1lX6w=
-github.com/shoenig/test v0.6.2/go.mod h1:byHiCGXqrVaflBLAMq/srcZIHynQPQgeyvkvXnjqq0k=
+github.com/shoenig/test v0.6.3 h1:GVXWJFk9PiOjN0KoJ7VrJGH6uLPnqxR7/fe3HUPfE0c=
+github.com/shoenig/test v0.6.3/go.mod h1:byHiCGXqrVaflBLAMq/srcZIHynQPQgeyvkvXnjqq0k=

--- a/hashset.go
+++ b/hashset.go
@@ -261,6 +261,8 @@ func (s *HashSet[T, H]) Copy() *HashSet[T, H] {
 }
 
 // Slice creates a copy of s as a slice.
+//
+// The result is not ordered.
 func (s *HashSet[T, H]) Slice() []T {
 	result := make([]T, 0, s.Size())
 	for _, item := range s.items {

--- a/set.go
+++ b/set.go
@@ -195,7 +195,7 @@ func (s *Set[T]) ContainsAll(items []T) bool {
 // If the slice is known to be set-like (no duplicates), EqualSlice provides
 // a more efficient implementation.
 func (s *Set[T]) ContainsSlice(items []T) bool {
-	return s.Equal(From[T](items))
+	return s.Equal(From(items))
 }
 
 // Subset returns whether o is a subset of s.

--- a/treeset.go
+++ b/treeset.go
@@ -1,0 +1,789 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package set
+
+import (
+	"fmt"
+)
+
+// Compare represents a function that compares two elements.
+//
+// Must return
+// < 0 if the first parameter is less than the second parameter
+// 0 if the two parameters are equal
+// > 0 if the first parameters is greater than the second parameter
+type Compare[T any] func(T, T) int
+
+// BuiltIn types compatible with Cmp
+type BuiltIn interface {
+	~string | ~int | ~uint | ~int64 | ~uint64 | ~int32 | ~uint32 | ~int16 | ~uint16 | ~int8 | ~uint8
+}
+
+// Cmp is a Compare function for the specified builtin type B.
+//
+// Common to use with string, int, etc.
+func Cmp[B BuiltIn](x, y B) int {
+	switch {
+	case x < y:
+		return -1
+	case x > y:
+		return 1
+	default:
+		return 0
+	}
+}
+
+// TreeSet provides a generic sortable set implementation for Go.
+// Enables fast storage and retrieval of ordered information. Most effective
+// in cases where data is regularly being added and/or removed and fast
+// lookup properties must be maintained.
+//
+// The underlying data structure is a Red-Black Binary Search Tree.
+// https://en.wikipedia.org/wiki/Red–black_tree
+//
+// Not thread safe, and not safe for concurrent modification.
+type TreeSet[T any, C Compare[T]] struct {
+	comparison C
+	root       *node[T]
+	marker     *node[T]
+	size       int
+}
+
+// NewTreeSet creates a TreeSet of type T, comparing elements via C.
+//
+// T may be any type.
+//
+// C is an implementation of Compare[T]. For builtin types, Cmp provides
+// a convenient Compare implementation.
+func NewTreeSet[T any, C Compare[T]](compare C) *TreeSet[T, C] {
+	return &TreeSet[T, C]{
+		comparison: compare,
+		root:       nil,
+		marker:     &node[T]{color: black},
+		size:       0,
+	}
+}
+
+// TreeSetFrom creates a new TreeSet containing each item in items.
+//
+// T may be any type.
+//
+// C is an implementation of Compare[T]. For builtin types, Cmp provides a
+// convenient Compare implementation.
+func TreeSetFrom[T any, C Compare[T]](items []T, compare C) *TreeSet[T, C] {
+	s := NewTreeSet[T](compare)
+	s.InsertSlice(items)
+	return s
+}
+
+// Insert item into s.
+//
+// Returns true if s was modified (item was not already in s), false otherwise.
+func (s *TreeSet[T, C]) Insert(item T) bool {
+	return s.insert(&node[T]{
+		element: item,
+		color:   red,
+	})
+}
+
+// InsertSlice will insert each item in items into s.
+//
+// Return true if s was modified (at least one item was not already in s), false otherwise.
+func (s *TreeSet[T, C]) InsertSlice(items []T) bool {
+	modified := false
+	for _, item := range items {
+		if s.Insert(item) {
+			modified = true
+		}
+	}
+	return modified
+}
+
+// Remove item from s.
+//
+// Returns true if s was modified (item was in s), false otherwise.
+func (s *TreeSet[T, C]) Remove(item T) bool {
+	return s.delete(item)
+}
+
+// RemoveSlice will remove each item in items from s.
+//
+// Return true if s was modified (any item was in s), false otherwise.
+func (s *TreeSet[T, C]) RemoveSlice(items []T) bool {
+	modified := false
+	for _, item := range items {
+		if s.Remove(item) {
+			modified = true
+		}
+	}
+	return modified
+}
+
+// Min returns the smallest item in the set.
+//
+// Must not be called on an empty set.
+func (s *TreeSet[T, C]) Min() T {
+	if s.root == nil {
+		panic("min: tree is empty")
+	}
+	n := s.min(s.root)
+	return n.element
+}
+
+// Max returns the largest item in s.
+//
+// Must not be called on an empty set.
+func (s *TreeSet[T, C]) Max() T {
+	if s.root == nil {
+		panic("max: tree is empty")
+	}
+	n := s.max(s.root)
+	return n.element
+}
+
+// TopK returns the top n (smallest) elements in s, in ascending order.
+func (s *TreeSet[T, C]) TopK(n int) []T {
+	result := make([]T, 0, n)
+	s.fillLeft(s.root, &result)
+	return result
+}
+
+// BottomK returns the bottom n (largest) elements in s, in descending order.
+func (s *TreeSet[T, C]) BottomK(n int) []T {
+	result := make([]T, 0, n)
+	s.fillRight(s.root, &result)
+	return result
+}
+
+// Contains returns whether item is present in s.
+func (s *TreeSet[T, C]) Contains(item T) bool {
+	return s.locate(s.root, item) != nil
+}
+
+// ContainsSlice returns whether s contains the same set of elements that are in
+// items. The items slice may contain duplicate elements.
+//
+// If the items slice is known to be set-like (no duplicates), EqualSlice provides
+// a more efficient implementation.
+func (s *TreeSet[T, C]) ContainsSlice(items []T) bool {
+	for _, item := range items {
+		if !s.Contains(item) {
+			return false
+		}
+	}
+	return true
+}
+
+// Size returns the number of elements in s.
+func (s *TreeSet[T, C]) Size() int {
+	return s.size
+}
+
+// Empty returns true if there are no elements in s.
+func (s *TreeSet[T, C]) Empty() bool {
+	return s.Size() == 0
+}
+
+// Slice returns the elements of s as a slice, in order.
+func (s *TreeSet[T, C]) Slice() []T {
+	result := make([]T, 0, s.Size())
+	s.infix(func(n *node[T]) {
+		result = append(result, n.element)
+	}, s.root)
+	return result
+}
+
+// Subset returns whether o is a subset of s.
+func (s *TreeSet[T, C]) Subset(o *TreeSet[T, C]) bool {
+	// try the fast paths
+	if o.Empty() {
+		return true
+	}
+	if s.Empty() {
+		return false
+	}
+	if s.Size() < o.Size() {
+		return false
+	}
+	// iterate o, and increment s finding each element
+	// i.e. merge algorithm but with channels
+	iterO := o.iterate()
+	iterS := s.iterate()
+
+	idxO := 0
+	idxS := 0
+
+next:
+	for ; idxO < o.Size(); idxO++ {
+		nextO := <-iterO
+		for ; idxS < s.Size(); idxS++ {
+			nextS := <-iterS
+			cmp := s.compare(nextS, nextO)
+			switch {
+			case cmp > 0:
+				return false
+			case cmp < 0:
+				continue
+			default:
+				continue next
+			}
+		}
+		return false
+	}
+	return true
+}
+
+// Union returns a set that contains all elements of s and o combined.
+func (s *TreeSet[T, C]) Union(o *TreeSet[T, C]) *TreeSet[T, C] {
+	tree := NewTreeSet[T](s.comparison)
+	f := func(n *node[T]) { tree.Insert(n.element) }
+	s.prefix(f, s.root)
+	o.prefix(f, o.root)
+	return tree
+}
+
+// Difference returns a set that contains elements of s that are not in o.
+func (s *TreeSet[T, C]) Difference(o *TreeSet[T, C]) *TreeSet[T, C] {
+	tree := NewTreeSet[T](s.comparison)
+	f := func(n *node[T]) {
+		if !o.Contains(n.element) {
+			tree.Insert(n.element)
+		}
+	}
+	s.prefix(f, s.root)
+	return tree
+}
+
+// Intersect returns a set that contains elements that are present in both s and o.
+func (s *TreeSet[T, C]) Intersect(o *TreeSet[T, C]) *TreeSet[T, C] {
+	tree := NewTreeSet[T](s.comparison)
+	f := func(n *node[T]) {
+		if o.Contains(n.element) {
+			tree.Insert(n.element)
+		}
+	}
+	s.prefix(f, s.root)
+	return tree
+}
+
+// Copy creates a copy of s.
+//
+// Individual elements are reference copies.
+func (s *TreeSet[T, C]) Copy() *TreeSet[T, C] {
+	tree := NewTreeSet[T](s.comparison)
+	f := func(n *node[T]) {
+		tree.Insert(n.element)
+	}
+	s.prefix(f, s.root)
+	return tree
+}
+
+// Equal return whether s and o contain the same elements.
+func (s *TreeSet[T, C]) Equal(o *TreeSet[T, C]) bool {
+	// try the fast fail paths
+	if s.Empty() || o.Empty() {
+		return s.Size() == o.Size()
+	}
+	switch {
+	case s.Size() != o.Size():
+		return false
+	case s.comparison(s.Min(), o.Min()) != 0:
+		return false
+	case s.comparison(s.Max(), o.Max()) != 0:
+		return false
+	}
+
+	iterS := s.iterate()
+	iterO := o.iterate()
+	for i := 0; i < s.Size(); i++ {
+		nextS := <-iterS
+		nextO := <-iterO
+		if s.compare(nextS, nextO) != 0 {
+			return false
+		}
+	}
+
+	return true
+}
+
+// EqualSlice returns whether s and items contain the same elements.
+func (s *TreeSet[T, C]) EqualSlice(items []T) bool {
+	if s.Size() != len(items) {
+		return false
+	}
+	return s.ContainsSlice(items)
+}
+
+// String creates a string representation of s, using "%v" printf formatting
+// each element into a string. The result contains elements in order.
+func (s *TreeSet[T, C]) String() string {
+	return s.StringFunc(func(element T) string {
+		return fmt.Sprintf("%v", element)
+	})
+}
+
+// StringFunc creates a string representation of s, using f to transform each
+// element into a string. The result contains elements in order.
+func (s *TreeSet[T, C]) StringFunc(f func(element T) string) string {
+	l := make([]string, 0, s.Size())
+	s.infix(func(n *node[T]) {
+		l = append(l, f(n.element))
+	}, s.root)
+	return fmt.Sprintf("%s", l)
+}
+
+// Red-Black Tree Invariants
+//
+// 1. each node is either red or black
+// 2. the root node is always black
+// 3. nil leaf nodes are always black
+// 4. a red node must not have red children
+// 5. all simple paths from a node to nil leaf contain the same number of
+// black nodes
+
+type color bool
+
+const (
+	red   color = false
+	black color = true
+)
+
+type node[T any] struct {
+	element T
+	color   color
+	parent  *node[T]
+	left    *node[T]
+	right   *node[T]
+}
+
+func (n *node[T]) black() bool {
+	return n == nil || n.color == black
+}
+
+func (n *node[T]) red() bool {
+	return n != nil && n.color == red
+}
+
+func (s *TreeSet[T, C]) locate(start *node[T], target T) *node[T] {
+	n := start
+	for {
+		if n == nil {
+			return nil
+		}
+		cmp := s.compare(n, &node[T]{element: target})
+		switch {
+		case cmp < 0:
+			n = n.right
+		case cmp > 0:
+			n = n.left
+		default:
+			return n
+		}
+	}
+}
+
+func (s *TreeSet[T, C]) rotateRight(n *node[T]) {
+	parent := n.parent
+	leftChild := n.left
+
+	n.left = leftChild.right
+	if leftChild.right != nil {
+		leftChild.right.parent = n
+	}
+
+	leftChild.right = n
+	n.parent = leftChild
+
+	s.replaceChild(parent, n, leftChild)
+}
+
+func (s *TreeSet[T, C]) rotateLeft(n *node[T]) {
+	parent := n.parent
+	rightChild := n.right
+
+	n.right = rightChild.left
+	if rightChild.left != nil {
+		rightChild.left.parent = n
+	}
+
+	rightChild.left = n
+	n.parent = rightChild
+
+	s.replaceChild(parent, n, rightChild)
+}
+
+func (s *TreeSet[T, C]) replaceChild(parent, previous, next *node[T]) {
+	switch {
+	case parent == nil:
+		s.root = next
+	case parent.left == previous:
+		parent.left = next
+	case parent.right == previous:
+		parent.right = next
+	default:
+		panic("node is not child of its parent")
+	}
+
+	if next != nil {
+		next.parent = parent
+	}
+}
+
+func (s *TreeSet[T, C]) insert(n *node[T]) bool {
+	var (
+		parent *node[T] = nil
+		tmp    *node[T] = s.root
+	)
+
+	for tmp != nil {
+		parent = tmp
+
+		cmp := s.compare(n, tmp)
+		switch {
+		case cmp < 0:
+			tmp = tmp.left
+		case cmp > 0:
+			tmp = tmp.right
+		default:
+			// already exists in tree
+			return false
+		}
+	}
+
+	n.color = red
+	switch {
+	case parent == nil:
+		s.root = n
+	case s.compare(n, parent) < 0:
+		parent.left = n
+	default:
+		parent.right = n
+	}
+	n.parent = parent
+
+	s.rebalanceInsertion(n)
+	s.size++
+	return true
+}
+
+func (s *TreeSet[T, C]) rebalanceInsertion(n *node[T]) {
+	parent := n.parent
+
+	// case 1: parent is nil
+	// - means we are the root
+	// - our color must be black
+	if parent == nil {
+		n.color = black
+		return
+	}
+
+	// if parent is black there is nothing to do
+	if parent.black() {
+		return
+	}
+
+	// case 2: no grandparent
+	// - implies the parent is root
+	// - we must now be black
+	grandparent := parent.parent
+	if grandparent == nil {
+		parent.color = black
+		return
+	}
+
+	uncle := s.uncleOf(parent)
+
+	switch {
+	// case 3: uncle is red
+	// - fix color of parent, grandparent, uncle
+	// - recurse upwards as necessary
+	case uncle != nil && uncle.red():
+		parent.color = black
+		grandparent.color = red
+		uncle.color = black
+		s.rebalanceInsertion(grandparent)
+
+	case parent == grandparent.left:
+		// case 4a: uncle is black
+		// + node is left->right child of its grandparent
+		if n == parent.right {
+			s.rotateLeft(parent)
+			parent = n // recolor in case 5a
+		}
+
+		// case 5a: uncle is black
+		// + node is left->left child of its grandparent
+		s.rotateRight(grandparent)
+
+		// fix color of original parent and grandparent
+		parent.color = black
+		grandparent.color = red
+
+		// parent is right child of grandparent
+	default:
+		// case 4b: uncle is black
+		// + node is right->left child of its grandparent
+		if n == parent.left {
+			s.rotateRight(parent)
+			// points to root of rotated sub tree
+			parent = n // recolor in case 5b
+		}
+
+		// case 5b: uncle is black
+		// + node is right->right child of its grandparent
+		s.rotateLeft(grandparent)
+
+		// fix color of original parent and grandparent
+		parent.color = black
+		grandparent.color = red
+	}
+}
+
+func (s *TreeSet[T, C]) delete(element T) bool {
+	n := s.locate(s.root, element)
+	if n == nil {
+		return false
+	}
+
+	var (
+		moved   *node[T]
+		deleted color
+	)
+
+	if n.left == nil || n.right == nil {
+		// case where deleted node had zero or one child
+		moved = s.delete01(n)
+		deleted = n.color
+	} else {
+		// case where node has two children
+
+		// find minimum of right subtree
+		successor := s.min(n.right)
+
+		// copy successor data into n
+		n.element = successor.element
+
+		// delete successor
+		moved = s.delete01(successor)
+		deleted = successor.color
+	}
+
+	// re-balance if the node was black
+	if deleted == black {
+		s.rebalanceDeletion(moved)
+
+		// remove marker
+		if moved == s.marker {
+			s.replaceChild(moved.parent, moved, nil)
+		}
+	}
+
+	// element was removed
+	s.size--
+	s.marker.color = black
+	s.marker.left = nil
+	s.marker.right = nil
+	s.marker.parent = nil
+	return true
+}
+
+func (s *TreeSet[T, C]) delete01(n *node[T]) *node[T] {
+	// node only has left child, replace by left child
+	if n.left != nil {
+		s.replaceChild(n.parent, n, n.left)
+		return n.left
+	}
+
+	// node only has right child, replace by right child
+	if n.right != nil {
+		s.replaceChild(n.parent, n, n.right)
+		return n.right
+	}
+
+	// node has both children
+	// if node is black replace with marker
+	// if node is red we just remove it
+	if n.black() {
+		s.replaceChild(n.parent, n, s.marker)
+		return s.marker
+	} else {
+		s.replaceChild(n.parent, n, nil)
+		return nil
+	}
+}
+
+func (s *TreeSet[T, C]) rebalanceDeletion(n *node[T]) {
+	// base case: node is root
+	if n == s.root {
+		n.color = black
+		return
+	}
+
+	sibling := s.siblingOf(n)
+
+	// case: sibling is red
+	if sibling.red() {
+		s.fixRedSibling(n, sibling)
+		sibling = s.siblingOf(n)
+	}
+
+	// case: black sibling with two black children
+	if sibling.left.black() && sibling.right.black() {
+		sibling.color = red
+
+		// case: black sibling with to black children and a red parent
+		if n.parent.red() {
+			n.parent.color = black
+		} else {
+			// case: black sibling with two black children and black parent
+			s.rebalanceDeletion(n.parent)
+		}
+	} else {
+		// case: black sibling with at least one red child
+		s.fixBlackSibling(n, sibling)
+	}
+}
+
+func (s *TreeSet[T, C]) fixRedSibling(n *node[T], sibling *node[T]) {
+	sibling.color = black
+	n.parent.color = red
+
+	switch {
+	case n == n.parent.left:
+		s.rotateLeft(n.parent)
+	default:
+		s.rotateRight(n.parent)
+	}
+}
+
+func (s *TreeSet[T, C]) fixBlackSibling(n, sibling *node[T]) {
+	isLeftChild := n == n.parent.left
+
+	if isLeftChild && sibling.right.black() {
+		sibling.left.color = black
+		sibling.color = red
+		s.rotateRight(sibling)
+		sibling = n.parent.right
+	} else if !isLeftChild && sibling.left.black() {
+		sibling.right.color = black
+		sibling.color = red
+		s.rotateLeft(sibling)
+		sibling = n.parent.left
+	}
+
+	sibling.color = n.parent.color
+	n.parent.color = black
+	if isLeftChild {
+		sibling.right.color = black
+		s.rotateLeft(n.parent)
+	} else {
+		sibling.left.color = black
+		s.rotateRight(n.parent)
+	}
+}
+
+func (s *TreeSet[T, C]) siblingOf(n *node[T]) *node[T] {
+	parent := n.parent
+	switch {
+	case n == parent.left:
+		return parent.right
+	case n == parent.right:
+		return parent.left
+	default:
+		panic("bug: parent is not a child of its grandparent")
+	}
+}
+
+func (*TreeSet[T, C]) uncleOf(n *node[T]) *node[T] {
+	grandparent := n.parent
+	switch {
+	case grandparent.left == n:
+		return grandparent.right
+	case grandparent.right == n:
+		return grandparent.left
+	default:
+		panic("bug: parent is not a child of our childs grandparent")
+	}
+}
+
+func (s *TreeSet[T, C]) min(n *node[T]) *node[T] {
+	for n.left != nil {
+		n = n.left
+	}
+	return n
+}
+
+func (s *TreeSet[T, C]) max(n *node[T]) *node[T] {
+	for n.right != nil {
+		n = n.right
+	}
+	return n
+}
+
+func (s *TreeSet[T, C]) compare(a, b *node[T]) int {
+	return s.comparison(a.element, b.element)
+}
+
+func (s *TreeSet[T, C]) infix(visit func(*node[T]), n *node[T]) {
+	if n == nil {
+		return
+	}
+	s.infix(visit, n.left)
+	visit(n)
+	s.infix(visit, n.right)
+}
+
+func (s *TreeSet[T, C]) fillLeft(n *node[T], k *[]T) {
+	if n == nil {
+		return
+	}
+
+	if len(*k) < cap(*k) {
+		s.fillLeft(n.left, k)
+	}
+
+	if len(*k) < cap(*k) {
+		*k = append(*k, n.element)
+	}
+
+	if len(*k) < cap(*k) {
+		s.fillLeft(n.right, k)
+	}
+}
+
+func (s *TreeSet[T, C]) fillRight(n *node[T], k *[]T) {
+	if n == nil {
+		return
+	}
+
+	if len(*k) < cap(*k) {
+		s.fillRight(n.right, k)
+	}
+
+	if len(*k) < cap(*k) {
+		*k = append(*k, n.element)
+	}
+
+	if len(*k) < cap(*k) {
+		s.fillRight(n.left, k)
+	}
+}
+
+func (s *TreeSet[T, C]) prefix(visit func(*node[T]), n *node[T]) {
+	if n == nil {
+		return
+	}
+	visit(n)
+	s.prefix(visit, n.left)
+	s.prefix(visit, n.right)
+}
+
+func (s *TreeSet[T, C]) iterate() <-chan *node[T] {
+	c := make(chan *node[T], 1)
+	v := func(n *node[T]) {
+		c <- n
+	}
+	go s.infix(v, s.root)
+	return c
+}

--- a/treeset_test.go
+++ b/treeset_test.go
@@ -1,0 +1,635 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package set
+
+import (
+	"fmt"
+	"math/rand"
+	"strings"
+	"testing"
+
+	"github.com/shoenig/test/must"
+)
+
+const (
+	size = 1000
+)
+
+type token struct {
+	id string
+}
+
+func (t *token) String() string {
+	return t.id
+}
+
+func compareTokens(a, b *token) int {
+	return Cmp(a.id, b.id)
+}
+
+var (
+	tokenA = &token{id: "A"}
+	tokenB = &token{id: "B"}
+	tokenC = &token{id: "C"}
+	tokenD = &token{id: "D"}
+	tokenE = &token{id: "E"}
+	tokenF = &token{id: "F"}
+	tokenG = &token{id: "G"}
+	tokenH = &token{id: "H"}
+)
+
+func TestNewTreeSet(t *testing.T) {
+	ts := NewTreeSet[*token, Compare[*token]](compareTokens)
+	must.NotNil(t, ts)
+	ts.dump()
+}
+
+func TestTreeSetFrom(t *testing.T) {
+	s := shuffle(ints(10))
+	ts := TreeSetFrom[int, Compare[int]](s, Cmp[int])
+	must.NotEmpty(t, ts)
+}
+
+func TestTreeSet_Empty(t *testing.T) {
+	t.Run("empty", func(t *testing.T) {
+		ts := NewTreeSet[int, Compare[int]](Cmp[int])
+		must.Empty(t, ts)
+	})
+
+	t.Run("not empty", func(t *testing.T) {
+		ts := NewTreeSet[int, Compare[int]](Cmp[int])
+		ts.Insert(1)
+		must.NotEmpty(t, ts)
+	})
+}
+
+func TestTreeSet_Size(t *testing.T) {
+	t.Run("empty", func(t *testing.T) {
+		ts := NewTreeSet[int, Compare[int]](Cmp[int])
+		must.Size(t, 0, ts)
+	})
+	t.Run("one", func(t *testing.T) {
+		ts := NewTreeSet[int, Compare[int]](Cmp[int])
+		ts.Insert(42)
+		must.Size(t, 1, ts)
+	})
+	t.Run("ten", func(t *testing.T) {
+		ts := NewTreeSet[int, Compare[int]](Cmp[int])
+		s := shuffle(ints(10))
+		for i := 0; i < len(s); i++ {
+			ts.Insert(s[i])
+			must.Size(t, i+1, ts)
+		}
+		// insert again (all duplicates)
+		s = shuffle(s)
+		for i := 0; i < len(s); i++ {
+			ts.Insert(s[i])
+			must.Size(t, 10, ts)
+		}
+	})
+}
+
+func TestTreeSet_Insert_token(t *testing.T) {
+	ts := NewTreeSet[*token, Compare[*token]](compareTokens)
+
+	ts.Insert(tokenA)
+	invariants(t, ts, compareTokens)
+
+	ts.Insert(tokenB)
+	invariants(t, ts, compareTokens)
+
+	ts.Insert(tokenC)
+	invariants(t, ts, compareTokens)
+
+	ts.Insert(tokenD)
+	invariants(t, ts, compareTokens)
+
+	ts.Insert(tokenE)
+	invariants(t, ts, compareTokens)
+
+	ts.Insert(tokenF)
+	invariants(t, ts, compareTokens)
+
+	ts.Insert(tokenG)
+	invariants(t, ts, compareTokens)
+
+	ts.Insert(tokenH)
+	invariants(t, ts, compareTokens)
+
+	t.Log("dump: insert token")
+	t.Log(ts.dump())
+}
+
+func TestTreeSet_Insert_int(t *testing.T) {
+	cmp := Cmp[int]
+	ts := NewTreeSet[int, Compare[int]](cmp)
+
+	numbers := ints(size)
+	random := shuffle(numbers)
+
+	for _, i := range random {
+		ts.Insert(i)
+		invariants(t, ts, cmp)
+	}
+
+	t.Log("dump: insert int")
+	t.Log(ts.dump())
+}
+
+func TestTreeSet_InsertSlice(t *testing.T) {
+	cmp := Cmp[int]
+
+	numbers := ints(size)
+	random := shuffle(numbers)
+
+	ts := NewTreeSet[int, Compare[int]](cmp)
+	must.True(t, ts.InsertSlice(random))
+	must.Eq(t, numbers, ts.Slice())
+	must.False(t, ts.InsertSlice(numbers))
+}
+
+func TestTreeSet_Remove_int(t *testing.T) {
+	cmp := Cmp[int]
+	ts := NewTreeSet[int, Compare[int]](cmp)
+
+	numbers := ints(size)
+	random := shuffle(numbers)
+
+	// insert in random order
+	for _, i := range random {
+		ts.Insert(i)
+	}
+
+	invariants(t, ts, cmp)
+
+	// reshuffle
+	random = shuffle(random)
+
+	// remove every element in random order
+	for _, i := range random {
+		removed := ts.Remove(i)
+		t.Log("dump: remove", i)
+		t.Log(ts.dump())
+		must.True(t, removed)
+		invariants(t, ts, cmp)
+
+	}
+
+	// all gone
+	must.Empty(t, ts)
+}
+
+func TestTreeSet_RemoveSlice(t *testing.T) {
+	cmp := Cmp[int]
+	ts := NewTreeSet[int, Compare[int]](cmp)
+
+	numbers := ints(size)
+	random := shuffle(numbers)
+	ts.InsertSlice(random)
+
+	must.True(t, ts.RemoveSlice(numbers))
+	must.Empty(t, ts)
+}
+
+func TestTreeSet_Contains(t *testing.T) {
+	t.Run("empty", func(t *testing.T) {
+		ts := NewTreeSet[int, Compare[int]](Cmp[int])
+		must.False(t, ts.Contains(42))
+	})
+
+	t.Run("exists", func(t *testing.T) {
+		ts := TreeSetFrom[int, Compare[int]]([]int{1, 2, 3, 4, 5}, Cmp[int])
+		must.Contains[int](t, 1, ts)
+		must.Contains[int](t, 2, ts)
+		must.Contains[int](t, 3, ts)
+		must.Contains[int](t, 4, ts)
+		must.Contains[int](t, 5, ts)
+	})
+
+	t.Run("absent", func(t *testing.T) {
+		ts := TreeSetFrom[int, Compare[int]]([]int{1, 2, 3, 4, 5}, Cmp[int])
+		must.NotContains[int](t, 0, ts)
+		must.NotContains[int](t, 6, ts)
+	})
+}
+
+func TestTreeSet_ContainsSlice(t *testing.T) {
+	t.Run("empty", func(t *testing.T) {
+		ts := NewTreeSet[int, Compare[int]](Cmp[int])
+		must.False(t, ts.ContainsSlice([]int{42, 43, 44}))
+	})
+
+	t.Run("exists", func(t *testing.T) {
+		ts := TreeSetFrom[int, Compare[int]]([]int{1, 2, 3, 4, 5}, Cmp[int])
+		must.True(t, ts.ContainsSlice([]int{2, 1, 3}))
+		must.True(t, ts.ContainsSlice([]int{5, 4, 3, 2, 1}))
+	})
+
+	t.Run("absent", func(t *testing.T) {
+		ts := TreeSetFrom[int, Compare[int]]([]int{1, 2, 3, 4, 5}, Cmp[int])
+		must.False(t, ts.ContainsSlice([]int{6, 7, 8}))
+		must.False(t, ts.ContainsSlice([]int{4, 5, 6}))
+	})
+}
+
+func TestTreeSet_Subset(t *testing.T) {
+	t.Run("empty empty", func(t *testing.T) {
+		t1 := NewTreeSet[int, Compare[int]](Cmp[int])
+		t2 := NewTreeSet[int, Compare[int]](Cmp[int])
+		must.True(t, t1.Subset(t2))
+	})
+
+	t.Run("empty full", func(t *testing.T) {
+		t1 := NewTreeSet[int, Compare[int]](Cmp[int])
+		t2 := TreeSetFrom[int, Compare[int]]([]int{1, 2, 3}, Cmp[int])
+		must.False(t, t1.Subset(t2))
+	})
+
+	t.Run("full empty", func(t *testing.T) {
+		t1 := NewTreeSet[int, Compare[int]](Cmp[int])
+		t2 := TreeSetFrom[int, Compare[int]]([]int{1, 2, 3}, Cmp[int])
+		must.True(t, t2.Subset(t1))
+	})
+
+	t.Run("same", func(t *testing.T) {
+		t1 := TreeSetFrom[int, Compare[int]]([]int{2, 1, 3}, Cmp[int])
+		t2 := TreeSetFrom[int, Compare[int]]([]int{1, 2, 3}, Cmp[int])
+		must.True(t, t1.Subset(t2))
+		must.True(t, t2.Subset(t1))
+	})
+
+	t.Run("subset", func(t *testing.T) {
+		t1 := TreeSetFrom[int, Compare[int]]([]int{2, 1, 3}, Cmp[int])
+		t2 := TreeSetFrom[int, Compare[int]]([]int{5, 4, 1, 2, 3}, Cmp[int])
+		must.False(t, t1.Subset(t2))
+	})
+
+	t.Run("superset", func(t *testing.T) {
+		t1 := TreeSetFrom[int, Compare[int]]([]int{9, 7, 8, 5, 4, 2, 1, 3}, Cmp[int])
+		t2 := TreeSetFrom[int, Compare[int]]([]int{5, 1, 2, 8, 3}, Cmp[int])
+		must.True(t, t1.Subset(t2))
+	})
+}
+
+func TestTreeSet_Union(t *testing.T) {
+	t.Run("empty empty", func(t *testing.T) {
+		t1 := TreeSetFrom[int, Compare[int]](nil, Cmp[int])
+		t2 := TreeSetFrom[int, Compare[int]](nil, Cmp[int])
+		result := t1.Union(t2)
+		must.Empty(t, result)
+	})
+
+	t.Run("empty full", func(t *testing.T) {
+		t1 := TreeSetFrom[int, Compare[int]](nil, Cmp[int])
+		t2 := TreeSetFrom[int, Compare[int]]([]int{3, 1, 2}, Cmp[int])
+		result := t1.Union(t2)
+		must.NotEmpty(t, result)
+		must.Eq(t, []int{1, 2, 3}, result.Slice())
+	})
+
+	t.Run("full empty", func(t *testing.T) {
+		t1 := TreeSetFrom[int, Compare[int]]([]int{2, 3, 1}, Cmp[int])
+		t2 := TreeSetFrom[int, Compare[int]](nil, Cmp[int])
+		result := t1.Union(t2)
+		must.NotEmpty(t, result)
+		must.Eq(t, []int{1, 2, 3}, result.Slice())
+	})
+
+	t.Run("subset", func(t *testing.T) {
+		t1 := TreeSetFrom[int, Compare[int]]([]int{2, 3, 1}, Cmp[int])
+		t2 := TreeSetFrom[int, Compare[int]]([]int{2}, Cmp[int])
+		result := t1.Union(t2)
+		must.NotEmpty(t, result)
+		must.Eq(t, []int{1, 2, 3}, result.Slice())
+	})
+
+	t.Run("superset", func(t *testing.T) {
+		t1 := TreeSetFrom[int, Compare[int]]([]int{2, 3, 1}, Cmp[int])
+		t2 := TreeSetFrom[int, Compare[int]]([]int{2, 5, 1, 2, 4}, Cmp[int])
+		result := t1.Union(t2)
+		must.NotEmpty(t, result)
+		must.Eq(t, []int{1, 2, 3, 4, 5}, result.Slice())
+	})
+}
+
+func TestTreeSet_Difference(t *testing.T) {
+	t.Run("empty empty", func(t *testing.T) {
+		t1 := TreeSetFrom[int, Compare[int]](nil, Cmp[int])
+		t2 := TreeSetFrom[int, Compare[int]](nil, Cmp[int])
+		result := t1.Difference(t2)
+		must.Empty(t, result)
+	})
+
+	t.Run("empty full", func(t *testing.T) {
+		t1 := TreeSetFrom[int, Compare[int]](nil, Cmp[int])
+		t2 := TreeSetFrom[int, Compare[int]]([]int{1, 2, 3}, Cmp[int])
+		result := t1.Difference(t2)
+		must.Empty(t, result)
+	})
+
+	t.Run("full empty", func(t *testing.T) {
+		t1 := TreeSetFrom[int, Compare[int]]([]int{2, 1, 3}, Cmp[int])
+		t2 := TreeSetFrom[int, Compare[int]](nil, Cmp[int])
+		result := t1.Difference(t2)
+		must.NotEmpty(t, result)
+		must.Eq(t, []int{1, 2, 3}, result.Slice())
+	})
+
+	t.Run("subset", func(t *testing.T) {
+		t1 := TreeSetFrom[int, Compare[int]]([]int{3, 2, 4}, Cmp[int])
+		t2 := TreeSetFrom[int, Compare[int]]([]int{1, 2, 3, 4, 5}, Cmp[int])
+		result := t1.Difference(t2)
+		must.Empty(t, result)
+	})
+
+	t.Run("superset", func(t *testing.T) {
+		t1 := TreeSetFrom[int, Compare[int]]([]int{2, 1, 3, 4, 5}, Cmp[int])
+		t2 := TreeSetFrom[int, Compare[int]]([]int{1, 2, 5}, Cmp[int])
+		result := t1.Difference(t2)
+		must.NotEmpty(t, result)
+		must.Eq(t, []int{3, 4}, result.Slice())
+	})
+}
+
+func TestTreeSet_Intersect(t *testing.T) {
+	t.Run("empty empty", func(t *testing.T) {
+		t1 := TreeSetFrom[int, Compare[int]](nil, Cmp[int])
+		t2 := TreeSetFrom[int, Compare[int]](nil, Cmp[int])
+		result := t1.Intersect(t2)
+		must.Empty(t, result)
+	})
+
+	t.Run("empty full", func(t *testing.T) {
+		t1 := TreeSetFrom[int, Compare[int]](nil, Cmp[int])
+		t2 := TreeSetFrom[int, Compare[int]]([]int{1, 2, 3}, Cmp[int])
+		result := t1.Intersect(t2)
+		must.Empty(t, result)
+	})
+
+	t.Run("full empty", func(t *testing.T) {
+		t1 := TreeSetFrom[int, Compare[int]]([]int{1, 2, 3}, Cmp[int])
+		t2 := TreeSetFrom[int, Compare[int]](nil, Cmp[int])
+		result := t1.Intersect(t2)
+		must.Empty(t, result)
+	})
+
+	t.Run("overlap", func(t *testing.T) {
+		t1 := TreeSetFrom[int, Compare[int]]([]int{1, 2, 3, 4, 5, 6}, Cmp[int])
+		t2 := TreeSetFrom[int, Compare[int]]([]int{0, 4, 5, 7}, Cmp[int])
+		result := t1.Intersect(t2)
+		must.NotEmpty(t, result)
+		must.Eq(t, []int{4, 5}, result.Slice())
+	})
+}
+
+func TestTreeSet_Copy(t *testing.T) {
+	t.Run("empty", func(t *testing.T) {
+		t1 := NewTreeSet[int, Compare[int]](Cmp[int])
+		c := t1.Copy()
+		must.Empty(t, c)
+	})
+
+	t.Run("full", func(t *testing.T) {
+		t1 := TreeSetFrom[int, Compare[int]]([]int{1, 2, 3}, Cmp[int])
+		c := t1.Copy()
+		must.NotEmpty(t, c)
+		must.Eq(t, []int{1, 2, 3}, c.Slice())
+	})
+
+	t.Run("modify", func(t *testing.T) {
+		t1 := TreeSetFrom[int, Compare[int]]([]int{1, 2, 3}, Cmp[int])
+		c := t1.Copy()
+		c.Insert(4)
+		t1.Remove(2)
+		must.Eq(t, []int{1, 3}, t1.Slice())
+		must.Eq(t, []int{1, 2, 3, 4}, c.Slice())
+	})
+}
+
+func TestTreeSet_EqualSlice(t *testing.T) {
+	t.Run("empty empty", func(t *testing.T) {
+		ts := TreeSetFrom[int, Compare[int]](nil, Cmp[int])
+		must.True(t, ts.EqualSlice(nil))
+	})
+
+	t.Run("empty full", func(t *testing.T) {
+		ts := TreeSetFrom[int, Compare[int]](nil, Cmp[int])
+		must.False(t, ts.EqualSlice([]int{1, 2, 3}))
+	})
+
+	t.Run("matching", func(t *testing.T) {
+		ts := TreeSetFrom[int, Compare[int]]([]int{1, 2, 3, 4, 5, 6}, Cmp[int])
+		must.True(t, ts.EqualSlice([]int{3, 2, 1, 6, 5, 4}))
+	})
+
+	t.Run("different middle", func(t *testing.T) {
+		ts := TreeSetFrom[int, Compare[int]]([]int{1, 2, 3, 5, 6}, Cmp[int])
+		must.False(t, ts.EqualSlice([]int{3, 2, 9, 6, 5, 4}))
+	})
+}
+
+func TestTreeSet_Equal(t *testing.T) {
+	t.Run("empty empty", func(t *testing.T) {
+		t1 := TreeSetFrom[int, Compare[int]](nil, Cmp[int])
+		t2 := TreeSetFrom[int, Compare[int]](nil, Cmp[int])
+		must.Equal(t, t1, t2)
+	})
+
+	t.Run("empty full", func(t *testing.T) {
+		t1 := TreeSetFrom[int, Compare[int]](nil, Cmp[int])
+		t2 := TreeSetFrom[int, Compare[int]]([]int{1, 2, 3}, Cmp[int])
+		must.NotEqual(t, t1, t2)
+	})
+
+	t.Run("matching", func(t *testing.T) {
+		t1 := TreeSetFrom[int, Compare[int]]([]int{1, 2, 3, 4, 5, 6}, Cmp[int])
+		t2 := TreeSetFrom[int, Compare[int]]([]int{6, 5, 4, 3, 2, 1}, Cmp[int])
+		must.Equal(t, t1, t2)
+	})
+
+	t.Run("different min", func(t *testing.T) {
+		t1 := TreeSetFrom[int, Compare[int]]([]int{1, 2, 3, 4}, Cmp[int])
+		t2 := TreeSetFrom[int, Compare[int]]([]int{0, 2, 3, 4}, Cmp[int])
+		must.NotEqual(t, t1, t2)
+	})
+
+	t.Run("different max", func(t *testing.T) {
+		t1 := TreeSetFrom[int, Compare[int]]([]int{1, 2, 3, 4}, Cmp[int])
+		t2 := TreeSetFrom[int, Compare[int]]([]int{5, 3, 2, 1}, Cmp[int])
+		must.NotEqual(t, t1, t2)
+	})
+
+	t.Run("different middle", func(t *testing.T) {
+		t1 := TreeSetFrom[int, Compare[int]]([]int{1, 2, 3, 5, 6}, Cmp[int])
+		t2 := TreeSetFrom[int, Compare[int]]([]int{1, 2, 4, 5, 6}, Cmp[int])
+		must.NotEqual(t, t1, t2)
+	})
+}
+
+func TestTreeSet_TopK(t *testing.T) {
+	t.Run("empty", func(t *testing.T) {
+		ts := NewTreeSet[int, Compare[int]](Cmp[int])
+		result := ts.TopK(5)
+		must.Eq(t, []int{}, result)
+	})
+
+	t.Run("same size", func(t *testing.T) {
+		ts := TreeSetFrom[int, Compare[int]]([]int{3, 9, 1, 7, 5}, Cmp[int])
+		result := ts.TopK(5)
+		must.Eq(t, []int{1, 3, 5, 7, 9}, result)
+	})
+
+	t.Run("smaller k", func(t *testing.T) {
+		ts := TreeSetFrom[int, Compare[int]]([]int{3, 9, 1, 7, 5}, Cmp[int])
+		result := ts.TopK(3)
+		must.Eq(t, []int{1, 3, 5}, result)
+	})
+}
+
+func TestTreeSet_BottomK(t *testing.T) {
+	t.Run("empty", func(t *testing.T) {
+		ts := NewTreeSet[int, Compare[int]](Cmp[int])
+		result := ts.BottomK(5)
+		must.Eq(t, []int{}, result)
+	})
+
+	t.Run("same size", func(t *testing.T) {
+		ts := TreeSetFrom[int, Compare[int]]([]int{3, 9, 1, 7, 5}, Cmp[int])
+		result := ts.BottomK(5)
+		must.Eq(t, []int{9, 7, 5, 3, 1}, result)
+	})
+
+	t.Run("smaller k", func(t *testing.T) {
+		ts := TreeSetFrom[int, Compare[int]]([]int{3, 9, 1, 7, 5}, Cmp[int])
+		result := ts.BottomK(3)
+		must.Eq(t, []int{9, 7, 5}, result)
+	})
+}
+
+func TestTreeSet_Slice(t *testing.T) {
+	t.Run("empty", func(t *testing.T) {
+		ts := NewTreeSet[int, Compare[int]](Cmp[int])
+		result := ts.Slice()
+		must.Eq(t, []int{}, result)
+	})
+
+	t.Run("full", func(t *testing.T) {
+		ts := TreeSetFrom[int, Compare[int]]([]int{4, 2, 6, 1}, Cmp[int])
+		result := ts.Slice()
+		must.Eq(t, []int{1, 2, 4, 6}, result)
+	})
+}
+
+func TestTreeSet_String(t *testing.T) {
+	t.Run("empty", func(t *testing.T) {
+		ts := NewTreeSet[int, Compare[int]](Cmp[int])
+		result := ts.String()
+		must.Eq(t, "[]", result)
+	})
+
+	t.Run("full", func(t *testing.T) {
+		ts := TreeSetFrom[int, Compare[int]]([]int{4, 2, 6, 1}, Cmp[int])
+		result := ts.String()
+		must.Eq(t, "[1 2 4 6]", result)
+	})
+}
+
+func TestTreeSet_StringFunc(t *testing.T) {
+	f := func(i int) string { return fmt.Sprintf("%02d", i) }
+	t.Run("empty", func(t *testing.T) {
+		ts := NewTreeSet[int, Compare[int]](Cmp[int])
+		result := ts.StringFunc(f)
+		must.Eq(t, "[]", result)
+	})
+
+	t.Run("full", func(t *testing.T) {
+		ts := TreeSetFrom[int, Compare[int]]([]int{4, 2, 6, 1}, Cmp[int])
+		result := ts.StringFunc(f)
+		must.Eq(t, "[01 02 04 06]", result)
+	})
+}
+
+// create a colorful representation of the element in node
+func (n *node[T]) String() string {
+	if n.red() {
+		return fmt.Sprintf("\033[1;31m%v\033[0m", n.element)
+	}
+	return fmt.Sprintf("%v", n.element)
+}
+
+// output creates a colorful string representation of s
+func (s *TreeSet[T, C]) output(prefix, cprefix string, n *node[T], sb *strings.Builder) {
+	if n == nil {
+		return
+	}
+
+	sb.WriteString(prefix)
+	sb.WriteString(n.String())
+	sb.WriteString("\n")
+
+	if n.right != nil && n.left != nil {
+		s.output(cprefix+"├── ", cprefix+"│   ", n.right, sb)
+	} else if n.right != nil {
+		s.output(cprefix+"└── ", cprefix+"    ", n.right, sb)
+	}
+	if n.left != nil {
+		s.output(cprefix+"└── ", cprefix+"    ", n.left, sb)
+	}
+	if n.left == nil && n.right == nil {
+		return
+	}
+}
+
+// dump the output of s along with the slice string
+func (s *TreeSet[T, C]) dump() string {
+	var sb strings.Builder
+	sb.WriteString("\ntree:\n")
+	s.output("", "", s.root, &sb)
+	sb.WriteString("string:")
+	sb.WriteString(s.String())
+	return sb.String()
+}
+
+// invariants makes basic assertions about tree
+func invariants[T any, C Compare[T]](t *testing.T, tree *TreeSet[T, C], cmp C) {
+	// assert Slice elements are ascending
+	slice := tree.Slice()
+	must.AscendingCmp(t, slice, cmp)
+
+	// assert size of tree
+	size := tree.Size()
+	must.Eq(t, size, len(slice), must.Sprint("tree is wrong size"))
+
+	if size == 0 {
+		return
+	}
+
+	// assert slice[0] is the minimum
+	must.Min(t, slice[0], tree)
+
+	// assert slice[len(slice)-1] is the maximum
+	must.Max(t, slice[len(slice)-1], tree)
+}
+
+// ints will create a []int from 1 to n
+func ints(n int) []int {
+	s := make([]int, n)
+	for i := 0; i < n; i++ {
+		s[i] = i + 1
+	}
+	return s
+}
+
+// create a copy of s and shuffle
+func shuffle(s []int) []int {
+	c := make([]int, len(s))
+	copy(c, s)
+
+	n := len(c)
+	for i := 0; i < n; i++ {
+		swp := rand.Int31n(int32(n))
+		c[i], c[swp] = c[swp], c[i]
+	}
+	return c
+}


### PR DESCRIPTION
This PR adds `TreeSet` to the implemented set types.

A `TreeSet` has advantages in cases where the data being stored can be represented in some kind of order. Order-specific operations such as finding the minimum value of a set, finding the `TopK` or `BottomK` elements of a set, or iterating the elements of a set in order are dramatically less expensive when stored via binary search tree. A `TreeSet[T]` determines order between its elements via `Compare[T]`, where the implementation of `Compare` is provided by the user. The `Cmp[BuiltIn]` helper provides a convenience implementation of `Compare` for built-in types.

The `TreeSet` type is backed by an underlying Red-Black Binary Search Tree[0], a well established data structure found in major projects such as the Linux Kernel and Java Virtual Machine.

Benchmarks are provided below for comparing some operations across the different set types, including plain slices. The following table describes the expected asymptotic performance for some operations of each type.

|                    | slice         | Set           | HashSet       | TreeSet   |
| :--                | :--           | :--           | :--           | :--       |
| Insert (avg)       | O(1)          | O(1)          | O(1)          | O(log(n)) |
| Insert (worst)     | O(n)          | O(n)          | O(n)          | O(log(n)) |
| Delete (avg)       | O(n)          | O(1)          | O(1)          | O(log(n)) |
| Delete (worst)     | O(n)          | O(n)          | O(n)          | O(log(n)) |
| Contains           | O(n)          | O(1)          | O(1)          | O(log(n)) |
| Min                | O(n)          | O(n)          | O(n)          | O(log(n)) |
| TopK               | O(n * log(n)) | O(n * log(n)) | O(n * log(n)) | O(log(n)) |
| Iterate            | O(n)          | O(n)          | O(n)          | O(n)      |
| Iterate (in order) | O(n * log(n)) | O(n * log(n)) | O(n * log(n)) | O(n)      |

[0] https://en.wikipedia.org/wiki/Red–black_tree

```
Benchmark_Slice_Insert/10-12                   283483903                3.538 ns/op
Benchmark_Slice_Insert/1000-12                 554723365                3.249 ns/op
Benchmark_Slice_Insert/100000-12               626779956                2.414 ns/op
Benchmark_Slice_Insert/1000000-12              615125025                3.122 ns/op

Benchmark_Set_Insert/10-12                     19020508               117.2 ns/op
Benchmark_Set_Insert/1000-12                   19318110               117.0 ns/op
Benchmark_Set_Insert/100000-12                 18946682               116.8 ns/op
Benchmark_Set_Insert/1000000-12                13727908               125.4 ns/op

Benchmark_HashSet_Insert/10-12                 14467316               139.3 ns/op
Benchmark_HashSet_Insert/1000-12               15396433               140.8 ns/op
Benchmark_HashSet_Insert/100000-12             14508603               138.8 ns/op
Benchmark_HashSet_Insert/1000000-12            10585650               119.0 ns/op

Benchmark_TreeSet_Insert/10-12                 10633179               120.7 ns/op
Benchmark_TreeSet_Insert/1000-12               10658127               122.1 ns/op
Benchmark_TreeSet_Insert/100000-12             10504867               126.2 ns/op
Benchmark_TreeSet_Insert/1000000-12            10902920               125.9 ns/op

Benchmark_Slice_Minimum/10-12                  12310653                96.23 ns/op
Benchmark_Slice_Minimum/1000-12                  144500              8181 ns/op
Benchmark_Slice_Minimum/100000-12                  1434            819509 ns/op
Benchmark_Slice_Minimum/1000000-12                  134           8655484 ns/op

Benchmark_Set_Minimum/10-12                     5023794               235.9 ns/op
Benchmark_Set_Minimum/1000-12                     18967             63799 ns/op
Benchmark_Set_Minimum/100000-12                     124           9530887 ns/op
Benchmark_Set_Minimum/1000000-12                      9         112611542 ns/op

Benchmark_HashSet_Minimum/10-12                 4418487               269.0 ns/op
Benchmark_HashSet_Minimum/1000-12                 19364             61636 ns/op
Benchmark_HashSet_Minimum/100000-12                 128           9290069 ns/op
Benchmark_HashSet_Minimum/1000000-12                 10         110000279 ns/op

Benchmark_TreeSet_Minimum/10-12                591382812                2.018 ns/op
Benchmark_TreeSet_Minimum/1000-12              298672525                4.021 ns/op
Benchmark_TreeSet_Minimum/100000-12            208646332                5.738 ns/op
Benchmark_TreeSet_Minimum/1000000-12           181639167                6.598 ns/op

Benchmark_Slice_Contains/10-12                 246240872                4.866 ns/op
Benchmark_Slice_Contains/1000-12                3896030               305.8 ns/op
Benchmark_Slice_Contains/100000-12                41647             28732 ns/op
Benchmark_Slice_Contains/1000000-12                4068            288287 ns/op

Benchmark_Set_Contains/10-12                   190191267                6.304 ns/op
Benchmark_Set_Contains/1000-12                 183063370                6.526 ns/op
Benchmark_Set_Contains/100000-12               127484904                9.357 ns/op
Benchmark_Set_Contains/1000000-12              82559810                12.68 ns/op

Benchmark_HashSetContains/10-12                173321290                6.877 ns/op
Benchmark_HashSetContains/1000-12              166393195                7.205 ns/op
Benchmark_HashSetContains/100000-12            120025850                9.974 ns/op
Benchmark_HashSetContains/1000000-12           40584700                26.22 ns/op

Benchmark_TreeSetContains/10-12                167040844                7.163 ns/op
Benchmark_TreeSetContains/1000-12              51727203                22.68 ns/op
Benchmark_TreeSetContains/100000-12            42277028                27.81 ns/op
Benchmark_TreeSetContains/1000000-12           29599938                40.17 ns/op
```