### PR TITLE
sets: support json marshal/unmarshal

### DIFF
--- a/hashset.go
+++ b/hashset.go
@@ -322,3 +322,13 @@ func (s *HashSet[T, H]) EqualSlice(items []T) bool {
 	}
 	return s.ContainsAll(items)
 }
+
+// MarshalJSON implements the json.Marshaler interface.
+func (s *HashSet[T, H]) MarshalJSON() ([]byte, error) {
+	return marshalJson[T](s)
+}
+
+// UnmarshalJSON implements the json.Unmarshaler interface.
+func (s *HashSet[T, H]) UnmarshalJSON(data []byte) error {
+	return unmarshalJson[T](s, data)
+}

--- a/hashset_test.go
+++ b/hashset_test.go
@@ -5,6 +5,8 @@ package set
 
 import (
 	"fmt"
+	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/shoenig/test/must"
@@ -27,6 +29,21 @@ func (c *company) Hash() string {
 
 func (c *company) String() string {
 	return fmt.Sprintf("<%s %d>", c.address, c.floor)
+}
+func (c *company) MarshalJSON() ([]byte, error) {
+	return []byte(fmt.Sprintf("{\"%s\":%d}", c.address, c.floor)), nil
+}
+
+func (c *company) UnmarshalJSON(data []byte) error {
+	s := strings.TrimLeft(string(data), "{")
+	s = strings.TrimRight(s, "}")
+
+	splitSlice := strings.Split(s, ":")
+	address := strings.TrimLeft(splitSlice[0], "\"")
+	address = strings.TrimRight(address, "\"")
+	c.address = address
+	c.floor, _ = strconv.Atoi(splitSlice[1])
+	return nil
 }
 
 var (

--- a/serialization.go
+++ b/serialization.go
@@ -1,0 +1,25 @@
+package set
+
+import "encoding/json"
+
+// serializable is an interface that allows a set to be serialized
+type serializable[T any] interface {
+	Slice() []T
+	InsertSlice([]T) bool
+}
+
+// marshalJson will serialize a Serializable[T] into a json byte array
+func marshalJson[T any](s serializable[T]) ([]byte, error) {
+	return json.Marshal(s.Slice())
+}
+
+// unmarshalJson will deserialize a json byte array into a Serializable[T]
+func unmarshalJson[T any](s serializable[T], data []byte) error {
+	slice := make([]T, 0)
+	err := json.Unmarshal(data, &slice)
+	if err != nil {
+		return err
+	}
+	s.InsertSlice(slice)
+	return nil
+}

--- a/serialization_test.go
+++ b/serialization_test.go
@@ -1,0 +1,53 @@
+package set
+
+import (
+	"encoding/json"
+	"github.com/shoenig/test/must"
+	"testing"
+)
+
+func TestSerialization(t *testing.T) {
+	t.Run("Set", func(t *testing.T) {
+		set := New[int](3)
+		set.InsertSlice([]int{1, 2, 3})
+		bs, err := json.Marshal(set)
+		must.NoError(t, err)
+		must.StrContains(t, string(bs), "1")
+		must.StrContains(t, string(bs), "2")
+		must.StrContains(t, string(bs), "3")
+
+		dstSet := New[int](3)
+		err = json.Unmarshal(bs, dstSet)
+		must.NoError(t, err)
+		must.MapEq(t, dstSet.items, set.items)
+	})
+	t.Run("HashSet", func(t *testing.T) {
+		set := NewHashSet[*company, string](10)
+		set.InsertSlice([]*company{c1, c2, c3})
+		bs, err := json.Marshal(set)
+		must.NoError(t, err)
+		must.StrContains(t, string(bs), `"street":1`)
+		must.StrContains(t, string(bs), `"street":2`)
+		must.StrContains(t, string(bs), `"street":3`)
+
+		dstSet := NewHashSet[*company, string](10)
+		err = json.Unmarshal(bs, dstSet)
+		must.NoError(t, err)
+		must.MapEqual(t, dstSet.items, set.items)
+	})
+	t.Run("TreeSet", func(t *testing.T) {
+		set := NewTreeSet[int, Compare[int]](Cmp[int])
+		set.InsertSlice([]int{10, 3, 13})
+		bs, err := json.Marshal(set)
+		must.NoError(t, err)
+		must.StrContains(t, string(bs), "10")
+		must.StrContains(t, string(bs), "3")
+		must.StrContains(t, string(bs), "13")
+
+		dstSet := NewTreeSet[int, Compare[int]](Cmp[int])
+		err = json.Unmarshal(bs, dstSet)
+		must.NoError(t, err)
+		must.Eq(t, set.Slice(), dstSet.Slice())
+	})
+
+}

--- a/set.go
+++ b/set.go
@@ -330,3 +330,13 @@ func (s *Set[T]) EqualSlice(items []T) bool {
 	}
 	return s.ContainsAll(items)
 }
+
+// MarshalJSON implements the json.Marshaler interface.
+func (s *Set[T]) MarshalJSON() ([]byte, error) {
+	return marshalJson[T](s)
+}
+
+// UnmarshalJSON implements the json.Unmarshaler interface.
+func (s *Set[T]) UnmarshalJSON(data []byte) error {
+	return unmarshalJson[T](s, data)
+}

--- a/set_test.go
+++ b/set_test.go
@@ -4,6 +4,7 @@
 package set
 
 import (
+	"encoding/json"
 	"fmt"
 	"testing"
 
@@ -662,4 +663,20 @@ func TestSet_EqualSlice(t *testing.T) {
 		b := []int{1, 2, 2, 3, 3, 4, 5}
 		must.False(t, a.EqualSlice(b))
 	})
+}
+
+func TestSetSerialization(t *testing.T) {
+	set := NewHashSet[*company, string](10)
+	set.InsertSlice([]*company{c1, c2, c3})
+	bs, err := json.Marshal(set)
+	must.NoError(t, err)
+	must.StrContains(t, string(bs), `"street":1`)
+	must.StrContains(t, string(bs), `"street":2`)
+	must.StrContains(t, string(bs), `"street":3`)
+
+	dstSet := NewHashSet[*company, string](10)
+	err = json.Unmarshal(bs, dstSet)
+	must.NoError(t, err)
+	must.MapEqual(t, dstSet.items, set.items)
+
 }

--- a/treeset.go
+++ b/treeset.go
@@ -787,3 +787,13 @@ func (s *TreeSet[T, C]) iterate() <-chan *node[T] {
 	go s.infix(v, s.root)
 	return c
 }
+
+// MarshalJSON implements the json.Marshaler interface.
+func (s *TreeSet[T, C]) MarshalJSON() ([]byte, error) {
+	return marshalJson[T](s)
+}
+
+// UnmarshalJSON implements the json.Unmarshaler interface.
+func (s *TreeSet[T, C]) UnmarshalJSON(data []byte) error {
+	return unmarshalJson[T](s, data)
+}


### PR DESCRIPTION
 Use serializable as a universal serialization interface。
set,treeSet,hashSet  can use marshalJson/unmarshalJson to implement MarshalJSON/UnmarshalJSON

Closes #22