### PR TITLE
trees: implement more TreeSet helper methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,10 +109,20 @@ Provides helper methods
 - Copy
 - Slice
 - String
-- Min (`TreeSet` only)
-- Max (`TreeSet` only)
-- TopK (`TreeSet` only)
-- BottomK (`TreeSet` only)
+
+TreeSet helper methods
+- Min
+- Max
+- TopK
+- BottomK
+- FirstAbove
+- FirstAboveEqual
+- Above
+- AboveEqual
+- FirstBelow
+- FirstBelowEqual
+- Below
+- BelowEqual
 
 # Install
 

--- a/treeset.go
+++ b/treeset.go
@@ -156,6 +156,42 @@ func (s *TreeSet[T, C]) BottomK(n int) []T {
 	return result
 }
 
+// Below returns a TreeSet containing the elements of s that are < item.
+func (s *TreeSet[T, C]) Below(item T) *TreeSet[T, C] {
+	result := NewTreeSet[T](s.comparison)
+	s.filterLeft(s.root, func(element T) bool {
+		return s.comparison(element, item) < 0
+	}, result)
+	return result
+}
+
+// BelowEqual returns a TreeSet containing the elements of s that are ≤ item.
+func (s *TreeSet[T, C]) BelowEqual(item T) *TreeSet[T, C] {
+	result := NewTreeSet[T](s.comparison)
+	s.filterLeft(s.root, func(element T) bool {
+		return s.comparison(element, item) <= 0
+	}, result)
+	return result
+}
+
+// After returns a TreeSet containing the elements of s that are > item.
+func (s *TreeSet[T, C]) Above(item T) *TreeSet[T, C] {
+	result := NewTreeSet[T](s.comparison)
+	s.filterRight(s.root, func(element T) bool {
+		return s.comparison(element, item) > 0
+	}, result)
+	return result
+}
+
+// AfterEqual returns a TreeSet containing the elements of s that are ≥ item.
+func (s *TreeSet[T, C]) AboveEqual(item T) *TreeSet[T, C] {
+	result := NewTreeSet[T](s.comparison)
+	s.filterRight(s.root, func(element T) bool {
+		return s.comparison(element, item) >= 0
+	}, result)
+	return result
+}
+
 // Contains returns whether item is present in s.
 func (s *TreeSet[T, C]) Contains(item T) bool {
 	return s.locate(s.root, item) != nil
@@ -796,4 +832,30 @@ func (s *TreeSet[T, C]) MarshalJSON() ([]byte, error) {
 // UnmarshalJSON implements the json.Unmarshaler interface.
 func (s *TreeSet[T, C]) UnmarshalJSON(data []byte) error {
 	return unmarshalJson[T](s, data)
+}
+
+func (s *TreeSet[T, C]) filterLeft(n *node[T], accept func(element T) bool, result *TreeSet[T, C]) {
+	if n == nil {
+		return
+	}
+
+	s.filterLeft(n.left, accept, result)
+
+	if accept(n.element) {
+		result.Insert(n.element)
+		s.filterLeft(n.right, accept, result)
+	}
+}
+
+func (s *TreeSet[T, C]) filterRight(n *node[T], accept func(element T) bool, result *TreeSet[T, C]) {
+	if n == nil {
+		return
+	}
+
+	s.filterRight(n.right, accept, result)
+
+	if accept(n.element) {
+		result.Insert(n.element)
+		s.filterRight(n.left, accept, result)
+	}
 }

--- a/treeset.go
+++ b/treeset.go
@@ -156,6 +156,46 @@ func (s *TreeSet[T, C]) BottomK(n int) []T {
 	return result
 }
 
+// FirstBelow returns the first element strictly below item.
+//
+// A zero value and false are returned if no such element exists.
+func (s *TreeSet[T, C]) FirstBelow(item T) (T, bool) {
+	var candidate *node[T] = nil
+	var n = s.root
+	for n != nil {
+		c := s.comparison(item, n.element)
+		switch {
+		case c > 0:
+			candidate = n
+			n = n.right
+		case c <= 0:
+			n = n.left
+		}
+	}
+	return candidate.get()
+}
+
+// FirstBelowEqual returns the first element below item (or item itself if present).
+//
+// A zero value and false are returned if no such element exists.
+func (s *TreeSet[T, C]) FirstBelowEqual(item T) (T, bool) {
+	var candidate *node[T] = nil
+	var n = s.root
+	for n != nil {
+		c := s.comparison(item, n.element)
+		switch {
+		case c == 0:
+			return n.get()
+		case c > 0:
+			candidate = n
+			n = n.right
+		case c < 0:
+			n = n.left
+		}
+	}
+	return candidate.get()
+}
+
 // Below returns a TreeSet containing the elements of s that are < item.
 func (s *TreeSet[T, C]) Below(item T) *TreeSet[T, C] {
 	result := NewTreeSet[T](s.comparison)
@@ -172,6 +212,46 @@ func (s *TreeSet[T, C]) BelowEqual(item T) *TreeSet[T, C] {
 		return s.comparison(element, item) <= 0
 	}, result)
 	return result
+}
+
+// FirstAbove returns the first element strictly above item.
+//
+// A zero value and false are returned if no such element exists.
+func (s *TreeSet[T, C]) FirstAbove(item T) (T, bool) {
+	var candidate *node[T] = nil
+	var n = s.root
+	for n != nil {
+		c := s.comparison(item, n.element)
+		switch {
+		case c < 0:
+			candidate = n
+			n = n.left
+		case c >= 0:
+			n = n.right
+		}
+	}
+	return candidate.get()
+}
+
+// FirstAboveEqual returns the first element above item (or item itself if present).
+//
+// A zero value and false are returned if no such element exists.
+func (s *TreeSet[T, C]) FirstAboveEqual(item T) (T, bool) {
+	var candidate *node[T]
+	var n = s.root
+	for n != nil {
+		c := s.comparison(item, n.element)
+		switch {
+		case c == 0:
+			return n.get()
+		case c < 0:
+			candidate = n
+			n = n.left
+		case c > 0:
+			n = n.right
+		}
+	}
+	return candidate.get()
 }
 
 // After returns a TreeSet containing the elements of s that are > item.
@@ -399,6 +479,14 @@ func (n *node[T]) black() bool {
 
 func (n *node[T]) red() bool {
 	return n != nil && n.color == red
+}
+
+func (n *node[T]) get() (T, bool) {
+	if n == nil {
+		var zero T
+		return zero, false
+	}
+	return n.element, true
 }
 
 func (s *TreeSet[T, C]) locate(start *node[T], target T) *node[T] {

--- a/treeset_test.go
+++ b/treeset_test.go
@@ -507,6 +507,114 @@ func TestTreeSet_BottomK(t *testing.T) {
 	})
 }
 
+func TestTreeSet_Below(t *testing.T) {
+	t.Run("empty", func(t *testing.T) {
+		ts := TreeSetFrom[int, Compare[int]]([]int{5, 6, 7, 8, 9}, Cmp[int])
+		b := ts.Below(5)
+		must.Empty(t, b)
+	})
+
+	t.Run("basic", func(t *testing.T) {
+		ts := TreeSetFrom[int, Compare[int]]([]int{4, 7, 1, 5, 2, 8, 9, 3}, Cmp[int])
+		b := ts.Below(5)
+		result := b.Slice()
+		must.Eq(t, []int{1, 2, 3, 4}, result)
+	})
+
+	t.Run("many", func(t *testing.T) {
+		ts := NewTreeSet[int, Compare[int]](Cmp[int])
+		nums := shuffle(ints(100))
+		ts.InsertSlice(nums)
+		for i := 2; i < 100; i++ {
+			below := ts.Below(i)
+			must.Size(t, i-1, below)
+			must.Min(t, 1, below)
+			must.Max(t, i-1, below)
+		}
+	})
+}
+
+func TestTreeSet_BelowEqual(t *testing.T) {
+	t.Run("empty", func(t *testing.T) {
+		ts := TreeSetFrom[int, Compare[int]]([]int{5, 6, 7, 8, 9}, Cmp[int])
+		b := ts.BelowEqual(4)
+		must.Empty(t, b)
+	})
+
+	t.Run("basic", func(t *testing.T) {
+		ts := TreeSetFrom[int, Compare[int]]([]int{4, 7, 1, 5, 2, 8, 9, 3}, Cmp[int])
+		b := ts.BelowEqual(5)
+		result := b.Slice()
+		must.Eq(t, []int{1, 2, 3, 4, 5}, result)
+	})
+
+	t.Run("many", func(t *testing.T) {
+		ts := NewTreeSet[int, Compare[int]](Cmp[int])
+		nums := shuffle(ints(100))
+		ts.InsertSlice(nums)
+		for i := 1; i < 100; i++ {
+			below := ts.BelowEqual(i)
+			must.Size(t, i, below)
+			must.Min(t, 1, below)
+			must.Max(t, i, below)
+		}
+	})
+}
+
+func TestTreeSet_Above(t *testing.T) {
+	t.Run("empty", func(t *testing.T) {
+		ts := TreeSetFrom[int, Compare[int]]([]int{5, 6, 7, 8, 9}, Cmp[int])
+		b := ts.Above(9)
+		must.Empty(t, b)
+	})
+
+	t.Run("basic", func(t *testing.T) {
+		ts := TreeSetFrom[int, Compare[int]]([]int{4, 7, 1, 5, 2, 8, 9, 3}, Cmp[int])
+		b := ts.Above(5)
+		result := b.Slice()
+		must.Eq(t, []int{7, 8, 9}, result)
+	})
+
+	t.Run("many", func(t *testing.T) {
+		ts := NewTreeSet[int, Compare[int]](Cmp[int])
+		nums := shuffle(ints(100))
+		ts.InsertSlice(nums)
+		for i := 1; i < 100; i++ {
+			above := ts.Above(i)
+			must.Size(t, 100-i, above)
+			must.Min(t, i+1, above)
+			must.Max(t, 100, above)
+		}
+	})
+}
+
+func TestTreeSet_AboveEqual(t *testing.T) {
+	t.Run("empty", func(t *testing.T) {
+		ts := TreeSetFrom[int, Compare[int]]([]int{5, 6, 7, 8, 9}, Cmp[int])
+		b := ts.AboveEqual(10)
+		must.Empty(t, b)
+	})
+
+	t.Run("basic", func(t *testing.T) {
+		ts := TreeSetFrom[int, Compare[int]]([]int{4, 7, 1, 5, 2, 8, 9, 3}, Cmp[int])
+		b := ts.AboveEqual(5)
+		result := b.Slice()
+		must.Eq(t, []int{5, 7, 8, 9}, result)
+	})
+
+	t.Run("many", func(t *testing.T) {
+		ts := NewTreeSet[int, Compare[int]](Cmp[int])
+		nums := shuffle(ints(100))
+		ts.InsertSlice(nums)
+		for i := 1; i < 100; i++ {
+			above := ts.AboveEqual(i)
+			must.Size(t, 100-i+1, above)
+			must.Min(t, i, above)
+			must.Max(t, 100, above)
+		}
+	})
+}
+
 func TestTreeSet_Slice(t *testing.T) {
 	t.Run("empty", func(t *testing.T) {
 		ts := NewTreeSet[int, Compare[int]](Cmp[int])

--- a/treeset_test.go
+++ b/treeset_test.go
@@ -507,6 +507,58 @@ func TestTreeSet_BottomK(t *testing.T) {
 	})
 }
 
+func TestTreeSet_FirstBelow(t *testing.T) {
+	t.Run("empty", func(t *testing.T) {
+		ts := NewTreeSet[int, Compare[int]](Cmp[int])
+		_, exists := ts.FirstBelow(5)
+		must.False(t, exists)
+	})
+
+	t.Run("basic", func(t *testing.T) {
+		ts := TreeSetFrom[int, Compare[int]]([]int{1, 3, 4, 5, 7, 8}, Cmp[int])
+		v, exists := ts.FirstBelow(5)
+		must.True(t, exists)
+		must.Eq(t, 4, v)
+	})
+
+	t.Run("many", func(t *testing.T) {
+		ts := NewTreeSet[int, Compare[int]](Cmp[int])
+		nums := shuffle(ints(100))
+		ts.InsertSlice(nums)
+		for i := 2; i < 100; i++ {
+			v, exists := ts.FirstBelow(i)
+			must.True(t, exists)
+			must.Eq(t, i-1, v)
+		}
+	})
+}
+
+func TestTreeSet_FirstBelowEqual(t *testing.T) {
+	t.Run("empty", func(t *testing.T) {
+		ts := NewTreeSet[int, Compare[int]](Cmp[int])
+		_, exists := ts.FirstBelowEqual(5)
+		must.False(t, exists)
+	})
+
+	t.Run("basic", func(t *testing.T) {
+		ts := TreeSetFrom[int, Compare[int]]([]int{1, 3, 4, 5, 7, 8}, Cmp[int])
+		v, exists := ts.FirstBelowEqual(5)
+		must.True(t, exists)
+		must.Eq(t, 5, v)
+	})
+
+	t.Run("many", func(t *testing.T) {
+		ts := NewTreeSet[int, Compare[int]](Cmp[int])
+		nums := shuffle(ints(100))
+		ts.InsertSlice(nums)
+		for i := 1; i < 100; i++ {
+			v, exists := ts.FirstBelowEqual(i)
+			must.True(t, exists)
+			must.Eq(t, i, v)
+		}
+	})
+}
+
 func TestTreeSet_Below(t *testing.T) {
 	t.Run("empty", func(t *testing.T) {
 		ts := TreeSetFrom[int, Compare[int]]([]int{5, 6, 7, 8, 9}, Cmp[int])
@@ -557,6 +609,58 @@ func TestTreeSet_BelowEqual(t *testing.T) {
 			must.Size(t, i, below)
 			must.Min(t, 1, below)
 			must.Max(t, i, below)
+		}
+	})
+}
+
+func TestTreeSet_FirstAbove(t *testing.T) {
+	t.Run("empty", func(t *testing.T) {
+		ts := TreeSetFrom[int, Compare[int]]([]int{2, 1, 3, 5, 4}, Cmp[int])
+		_, exists := ts.FirstAbove(5)
+		must.False(t, exists)
+	})
+
+	t.Run("basic", func(t *testing.T) {
+		ts := TreeSetFrom[int, Compare[int]]([]int{2, 1, 4, 6, 5, 7, 8}, Cmp[int])
+		v, exists := ts.FirstAbove(5)
+		must.True(t, exists)
+		must.Eq(t, 6, v)
+	})
+
+	t.Run("many", func(t *testing.T) {
+		ts := NewTreeSet[int, Compare[int]](Cmp[int])
+		nums := shuffle(ints(100))
+		ts.InsertSlice(nums)
+		for i := 1; i < 100; i++ {
+			v, exists := ts.FirstAbove(i)
+			must.True(t, exists)
+			must.Eq(t, i+1, v)
+		}
+	})
+}
+
+func TestTreeSet_FirstAboveEqual(t *testing.T) {
+	t.Run("empty", func(t *testing.T) {
+		ts := TreeSetFrom[int, Compare[int]]([]int{2, 1, 3, 4}, Cmp[int])
+		_, exists := ts.FirstAboveEqual(5)
+		must.False(t, exists)
+	})
+
+	t.Run("basic", func(t *testing.T) {
+		ts := TreeSetFrom[int, Compare[int]]([]int{2, 1, 4, 6, 5, 7, 8}, Cmp[int])
+		v, exists := ts.FirstAboveEqual(5)
+		must.True(t, exists)
+		must.Eq(t, 5, v)
+	})
+
+	t.Run("many", func(t *testing.T) {
+		ts := NewTreeSet[int, Compare[int]](Cmp[int])
+		nums := shuffle(ints(100))
+		ts.InsertSlice(nums)
+		for i := 1; i < 100; i++ {
+			v, exists := ts.FirstAboveEqual(i)
+			must.True(t, exists)
+			must.Eq(t, i, v)
 		}
 	})
 }


### PR DESCRIPTION
This PR implements the following helper methods on `TreeSet`

- `Below` - set of elements strictly below a value
- `BelowEqual` - set of elements below or equal to a value
- `FirstBelow` - first element strictly below a value (if exists)
- `FirstBelowEqual` - first element below or equal to a value (if exists)
- `Above` - set of elements strictly above a value
- `AboveEqual` - set of elements above or equal to a value
- `FirstAbove` - first element strictly above a value
- `FirstAboveEqual` - first element strictly 

Closes https://github.com/hashicorp/go-set/issues/37
Closes https://github.com/hashicorp/go-set/pull/38