### PR TITLE
treeset: avoid using goroutine / channel / context for iteration

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,9 +2,6 @@ module github.com/hashicorp/go-set
 
 go 1.18
 
-require (
-	github.com/shoenig/test v0.6.4
-	go.uber.org/goleak v1.2.1
-)
+require github.com/shoenig/test v0.6.4
 
 require github.com/google/go-cmp v0.5.9 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,10 +1,4 @@
-github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
-github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/shoenig/test v0.6.4 h1:kVTaSd7WLz5WZ2IaoM0RSzRsUD+m8wRR+5qvntpn4LU=
 github.com/shoenig/test v0.6.4/go.mod h1:byHiCGXqrVaflBLAMq/srcZIHynQPQgeyvkvXnjqq0k=
-github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
-go.uber.org/goleak v1.2.1 h1:NBol2c7O1ZokfZ0LEU9K6Whx/KnwvepVetCUhtKja4A=
-go.uber.org/goleak v1.2.1/go.mod h1:qlT2yGI9QafXHhZZLxlSuNsMw3FFLxBr+tBRlmO1xH4=
-gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/stack.go
+++ b/stack.go
@@ -1,0 +1,33 @@
+package set
+
+type stack[T any] struct {
+	top *object[T]
+}
+
+type object[T any] struct {
+	item T
+	next *object[T]
+}
+
+func makeStack[T any]() *stack[T] {
+	return new(stack[T])
+}
+
+func (s *stack[T]) push(item T) {
+	obj := &object[T]{
+		item: item,
+		next: s.top,
+	}
+	s.top = obj
+}
+
+func (s *stack[T]) pop() T {
+	obj := s.top
+	s.top = obj.next
+	obj.next = nil
+	return obj.item
+}
+
+func (s *stack[T]) empty() bool {
+	return s.top == nil
+}

--- a/stack_test.go
+++ b/stack_test.go
@@ -1,0 +1,48 @@
+package set
+
+import (
+	"testing"
+
+	"github.com/shoenig/test/must"
+)
+
+func TestStack_simple(t *testing.T) {
+	s := makeStack[int]()
+	must.True(t, s.empty())
+
+	s.push(1)
+	must.False(t, s.empty())
+
+	value := s.pop()
+	must.Eq(t, 1, value)
+	must.True(t, s.empty())
+}
+
+func TestStack_complex(t *testing.T) {
+	s := makeStack[byte]()
+
+	s.push('a')
+	s.push('b')
+	s.push('c')
+	s.push('d')
+	s.push('e')
+	s.push('f')
+
+	must.Eq(t, 'f', s.pop())
+	must.Eq(t, 'e', s.pop())
+	must.Eq(t, 'd', s.pop())
+
+	s.push('x')
+	s.push('y')
+
+	must.Eq(t, 'y', s.pop())
+
+	s.push('z')
+
+	must.Eq(t, 'z', s.pop())
+	must.Eq(t, 'x', s.pop())
+	must.Eq(t, 'c', s.pop())
+	must.Eq(t, 'b', s.pop())
+	must.Eq(t, 'a', s.pop())
+	must.True(t, s.empty())
+}

--- a/treeset_test.go
+++ b/treeset_test.go
@@ -4,14 +4,12 @@
 package set
 
 import (
-	"context"
 	"fmt"
 	"math/rand"
 	"strings"
 	"testing"
 
 	"github.com/shoenig/test/must"
-	"go.uber.org/goleak"
 )
 
 const (
@@ -922,21 +920,14 @@ func TestTreeSet_infix(t *testing.T) {
 	}, ts.root)
 	must.Eq(t, []int{1, 3, 5, 7}, odds)
 }
-func TestMain(m *testing.M) {
-	goleak.VerifyTestMain(m)
-}
 
-func TestTreeSet_iterate(t *testing.T) {
-	s := TreeSetFrom[int, Compare[int]]([]int{4, 7, 1, 5, 2, 8, 9, 3, 11}, Cmp[int])
-	ctx, cl := context.WithCancel(context.Background())
-	defer cl()
-	ret := make([]int, 0, 9)
-	ch := s.iterate(ctx)
-	for n := range ch {
-		if n.element > 3 {
-			break
-		}
-		ret = append(ret, n.element)
+func TestTreeSet_iterate2(t *testing.T) {
+	nums := shuffle(ints(11))
+	s := TreeSetFrom[int, Compare[int]](nums, Cmp[int])
+
+	iter := s.iterate()
+	for i := 1; i <= 11; i++ {
+		must.Eq(t, i, iter().element)
 	}
-	must.Eq(t, []int{1, 2, 3}, ret)
+	must.Nil(t, iter())
 }


### PR DESCRIPTION
This PR swaps implementations of `TreeSet.iterate` to not require a background goroutine, channel, and context. Instead we use an explicit stack and a generator function to "pull" values one at time. Unlike with the goroutine, the stack object is garbage collected automatically if we do not traverse the entire tree.

Inspiriation is from https://github.com/golang/go/discussions/56413