### PR TITLE
fix(treeset): fix RemoveFunc not remove all matched node (#63)

### DIFF
--- a/examples_treeset_test.go
+++ b/examples_treeset_test.go
@@ -157,20 +157,20 @@ func ExampleTreeSet_RemoveSet() {
 }
 
 func ExampleTreeSet_RemoveFunc() {
-	s := TreeSetFrom[int, Compare[int]]([]int{1, 2, 3, 4, 5, 6, 7, 8, 9}, Cmp[int])
+	s := TreeSetFrom[int, Compare[int]](ints(20), Cmp[int])
 
 	fmt.Println(s)
 
 	even := func(i int) bool {
-		return i%2 == 0
+		return i%3 != 0
 	}
 	s.RemoveFunc(even)
 
 	fmt.Println(s)
 
 	// Output:
-	// [1 2 3 4 5 6 7 8 9]
-	// [1 3 5 7 9]
+	// [1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20]
+	// [3 6 9 12 15 18]
 }
 
 func ExampleTreeSet_Contains() {

--- a/treeset.go
+++ b/treeset.go
@@ -154,15 +154,8 @@ func (s *TreeSet[T, C]) RemoveSet(o *TreeSet[T, C]) bool {
 //
 // Return true if s was modified, false otherwise.
 func (s *TreeSet[T, C]) RemoveFunc(f func(T) bool) bool {
-	modified := false
-	remove := func(item T) bool {
-		if f(item) && s.Remove(item) {
-			modified = true
-		}
-		return true
-	}
-	s.ForEach(remove)
-	return modified
+	removeIds := s.FilterSlice(f)
+	return s.RemoveSlice(removeIds)
 }
 
 // Min returns the smallest item in the set.
@@ -353,6 +346,18 @@ func (s *TreeSet[T, C]) Slice() []T {
 		result = append(result, n.element)
 		return true
 	}, s.root)
+	return result
+}
+
+// FilterSlice returns the elements of s that satisfy the predicate f.
+func (s *TreeSet[T, C]) FilterSlice(filter func(T) bool) []T {
+	result := make([]T, 0, s.Size())
+	s.ForEach(func(t T) bool {
+		if filter != nil && filter(t) {
+			result = append(result, t)
+		}
+		return true
+	})
 	return result
 }
 

--- a/treeset.go
+++ b/treeset.go
@@ -342,10 +342,10 @@ func (s *TreeSet[T, C]) Empty() bool {
 // Slice returns the elements of s as a slice, in order.
 func (s *TreeSet[T, C]) Slice() []T {
 	result := make([]T, 0, s.Size())
-	s.infix(func(n *node[T]) bool {
-		result = append(result, n.element)
+	s.ForEach(func(element T) bool {
+		result = append(result, element)
 		return true
-	}, s.root)
+	})
 	return result
 }
 
@@ -496,10 +496,10 @@ func (s *TreeSet[T, C]) String() string {
 // element into a string. The result contains elements in order.
 func (s *TreeSet[T, C]) StringFunc(f func(element T) string) string {
 	l := make([]string, 0, s.Size())
-	s.infix(func(n *node[T]) bool {
-		l = append(l, f(n.element))
+	s.ForEach(func(element T) bool {
+		l = append(l, f(element))
 		return true
-	}, s.root)
+	})
 	return fmt.Sprintf("%s", l)
 }
 
@@ -912,15 +912,17 @@ func (s *TreeSet[T, C]) compare(a, b *node[T]) int {
 // TreeNodeVisit is a function that is called for each node in the tree.
 type TreeNodeVisit[T any] func(*node[T]) (next bool)
 
-func (s *TreeSet[T, C]) infix(visit TreeNodeVisit[T], n *node[T]) {
+func (s *TreeSet[T, C]) infix(visit TreeNodeVisit[T], n *node[T]) (next bool) {
 	if n == nil {
+		return true
+	}
+	if next = s.infix(visit, n.left); !next {
 		return
 	}
-	s.infix(visit, n.left)
-	if !visit(n) {
+	if next = visit(n); !next {
 		return
 	}
-	s.infix(visit, n.right)
+	return s.infix(visit, n.right)
 }
 
 func (s *TreeSet[T, C]) fillLeft(n *node[T], k *[]T) {

--- a/treeset_test.go
+++ b/treeset_test.go
@@ -909,7 +909,7 @@ func TestTreeSet_infix(t *testing.T) {
 	}
 	odds := make([]int, 0, 5)
 	ts.infix(func(n *node[int]) bool {
-		if n.element > 8 {
+		if n.element == 8 {
 			return false
 		}
 		if isOdd(n) {


### PR DESCRIPTION
1. add a filterSlice method that returns the elements of s that satisfy the predicate as a slice, in order.
2. first find remove ids by filterSlice, secondly to remove by removeSlice
 

then I find other bug: 

infix can't stop when return in left node, and can to visist other node;
for example, I write a test, it can't stop in 8 .so I fix it.

![Pasted image 20230512171745](https://github.com/hashicorp/go-set/assets/26363539/5c61559a-970b-4d77-b60f-88055bba3b34)


