### PR TITLE
ci: setup copywrite step

### DIFF
--- a/.copywrite.hcl
+++ b/.copywrite.hcl
@@ -1,0 +1,12 @@
+schema_version = 1
+
+project {
+  license        = "MPL-2.0"
+  copyright_year = 2022
+  header_ignore = [
+    ".golangci.yaml",
+    ".copywrite.hcl",
+    ".github/**",
+  ]
+}
+

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,6 +11,14 @@ on:
       - README.md
       - .gitignore
 jobs:
+  run-copywrite:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
+      - uses: hashicorp/setup-copywrite@v1.1.2
+      - name: verify copyright
+        run: |
+          copywrite headers --plan
   run-lint:
     timeout-minutes: 10
     runs-on: ubuntu-22.04


### PR DESCRIPTION
This just runs our `copywrite` tool in dry run mode to make sure headers are set.