### PR TITLE
sets: implement .Items() for use with range keyword

### DIFF
--- a/hashset.go
+++ b/hashset.go
@@ -334,3 +334,17 @@ func (s *HashSet[T, H]) ForEach(visit func(T) bool) {
 		}
 	}
 }
+
+// Items returns a generator function for iterating each element in s by using
+// the range keyword.
+//
+//	for element := range s.Items() { ... }
+func (s *HashSet[T, H]) Items() func(func(T) bool) {
+	return func(yield func(T) bool) {
+		for _, item := range s.items {
+			if !yield(item) {
+				return
+			}
+		}
+	}
+}

--- a/hashset_test.go
+++ b/hashset_test.go
@@ -724,3 +724,17 @@ func TestHashSet_HashCode(t *testing.T) {
 	must.True(t, a.Contains(s2))
 	must.False(t, a.Contains(s3))
 }
+
+func TestHashSet_Items(t *testing.T) {
+	a := NewHashSet[*coded, int](0)
+	a.Insert(s1)
+	a.Insert(s2)
+	a.Insert(s3)
+
+	sum := 0
+	for element := range a.Items() {
+		sum += element.i
+	}
+
+	must.Eq(t, 6, sum)
+}

--- a/set.go
+++ b/set.go
@@ -8,6 +8,7 @@ package set
 
 import (
 	"fmt"
+	"iter"
 	"sort"
 )
 
@@ -302,6 +303,20 @@ func (s *Set[T]) ForEach(visit func(T) bool) {
 	for item := range s.items {
 		if !visit(item) {
 			return
+		}
+	}
+}
+
+// Items returns a generator function for iterating each element in s by using
+// the range keyword.
+//
+//	for element := range s.Items() { ... }
+func (s *Set[T]) Items() iter.Seq[T] {
+	return func(yield func(T) bool) {
+		for item := range s.items {
+			if !yield(item) {
+				return
+			}
 		}
 	}
 }

--- a/set_test.go
+++ b/set_test.go
@@ -763,3 +763,14 @@ func TestSet_ForEach(t *testing.T) {
 	sort.Ints(result)
 	must.Eq(t, []int{0, 2, 4, 6, 8}, result)
 }
+
+func TestSet_Items(t *testing.T) {
+	s := From[int]([]int{1, 2, 3, 4, 5})
+
+	sum := 0
+	for element := range s.Items() {
+		sum += element
+	}
+
+	must.Eq(t, 15, sum)
+}

--- a/treeset.go
+++ b/treeset.go
@@ -5,6 +5,7 @@ package set
 
 import (
 	"fmt"
+	"iter"
 )
 
 // CompareFunc represents a function that compares two elements.
@@ -1030,5 +1031,22 @@ func (s *TreeSet[T]) filterRight(n *node[T], accept func(element T) bool, result
 	if accept(n.element) {
 		result.Insert(n.element)
 		s.filterRight(n.left, accept, result)
+	}
+}
+
+// Items returns a generator function for iterating each element in s by using
+// the range keyword.
+//
+//	for i, element := range s.Items() { ... }
+func (s *TreeSet[T]) Items() iter.Seq2[int, T] {
+	return func(yield func(int, T) bool) {
+		iter := s.iterate()
+		n := iter()
+		for i := 0; n != nil; i++ {
+			if !yield(i, n.element) {
+				return
+			}
+			n = iter()
+		}
 	}
 }

--- a/treeset_test.go
+++ b/treeset_test.go
@@ -1011,3 +1011,19 @@ func TestTreeSet_iterate2(t *testing.T) {
 	}
 	must.Nil(t, iter())
 }
+
+func TestTreeSet_Items(t *testing.T) {
+	ts := TreeSetFrom[int]([]int{2, 1, 4, 3, 5}, Compare[int])
+
+	exp := []int{1, 2, 3, 4, 5}
+	idx := []int{0, 1, 2, 3, 4}
+	result := []int{}
+	idxs := []int{}
+	for i, element := range ts.Items() {
+		result = append(result, element)
+		idxs = append(idxs, i)
+	}
+
+	must.Eq(t, exp, result)
+	must.Eq(t, idx, idxs)
+}


### PR DESCRIPTION
This PR adds a .Items() method on each of Set, HashSet, and TreeSet
enabling each type to be used with the `range` keyword for iteration.

    for element := range s.Items() {
      // ...
    }

Note this is currently an experimental feature of Go 1.22
https://go.dev/wiki/RangefuncExperiment
