### PR TITLE
v3: implement Items() method for use with range keyword

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,31 +12,31 @@ on:
       - .gitignore
 jobs:
   run-copywrite:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
-      - uses: hashicorp/setup-copywrite@v1.1.2
+      - uses: hashicorp/setup-copywrite@v1.1.3
       - name: verify copyright
         run: |
           copywrite headers --plan
   run-lint:
     timeout-minutes: 10
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
-      - uses: hashicorp/setup-golang@v2
+      - uses: hashicorp/setup-golang@v3
         with:
           version-file: go.mod
       - uses: golangci/golangci-lint-action@3a919529898de77ec3da873e3063ca4b10e7f5cc # v3.7.0
         with:
-          version: v1.54.0
+          version: v1.60.1
           skip-cache: true
   run-tests:
     timeout-minutes: 10
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
-      - uses: hashicorp/setup-golang@v2
+      - uses: hashicorp/setup-golang@v3
         with:
           version-file: go.mod
       - name: Run Go Vet

--- a/README.md
+++ b/README.md
@@ -9,9 +9,15 @@ generic [Set](https://en.wikipedia.org/wiki/Set) implementations for Go.
 
 ---
 
-**PSA** October 2023 - The **v2** version of this package has been published, starting at
-tag version `v2.1.0`. A description of the changes including backwards incompatibilities
-can be found in https://github.com/hashicorp/go-set/issues/73
+**PSA** August 2024 - The **v3** version of this package has been published,
+starting at tag version `v3.0.0`. A description of the changes including
+backwards incompatibilities can be found in https://github.com/hashicorp/go-set/issues/90
+
+---
+
+**PSA** October 2023 - The **v2** version of this package has been published,
+starting at tag version `v2.1.0`. A description of the changes including
+backwards incompatibilities can be found in https://github.com/hashicorp/go-set/issues/73
 
 ---
 
@@ -113,17 +119,15 @@ It serves as a useful abstraction over the common methods implemented by each se
 
 ### Iteration
 
-Go still has no support for using `range` over user defined types. Until that becomes
-possible, each of `Set`, `HashSet`, and `TreeSet` implements a `ForEach` method for
-iterating each element in a set. The argument is a function that accepts an item from
-the set and returns a boolean, indicating whether iteration should be halted.
+Starting with `v3` each of `Set`, `HashSet`, and `TreeSet` implement an `Items`
+method. It can be used with the `range` keyword for iterating through each 
+element in the set.
 
 ```go
-// e.g. print each item in the set
-s.ForEach(func(item T) bool {
+// e.g. print each element in the set
+for _, item := range s.Items() {
   fmt.Println(item)
-  return true
-})
+}
 ```
 
 # Set Examples

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ generic [Set](https://en.wikipedia.org/wiki/Set) implementations for Go.
 starting at tag version `v3.0.0`. A description of the changes including
 backwards incompatibilities can be found in https://github.com/hashicorp/go-set/issues/90
 
+Requires `go1.23` or later.
 ---
 
 **PSA** October 2023 - The **v2** version of this package has been published,

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # go-set
 
-[![Go Reference](https://pkg.go.dev/badge/github.com/hashicorp/go-set.svg)](https://pkg.go.dev/github.com/hashicorp/go-set/v2)
+[![Go Reference](https://pkg.go.dev/badge/github.com/hashicorp/go-set.svg)](https://pkg.go.dev/github.com/hashicorp/go-set/v3)
 [![Run CI Tests](https://github.com/hashicorp/go-set/actions/workflows/ci.yaml/badge.svg)](https://github.com/hashicorp/go-set/actions/workflows/ci.yaml)
 [![GitHub](https://img.shields.io/github/license/hashicorp/go-set)](LICENSE)
 
@@ -44,16 +44,16 @@ This package is not thread-safe.
 
 # Documentation
 
-The full `go-set` package reference is available on [pkg.go.dev](https://pkg.go.dev/github.com/hashicorp/go-set/v2).
+The full `go-set` package reference is available on [pkg.go.dev](https://pkg.go.dev/github.com/hashicorp/go-set/v3).
 
 # Install
 
 ```shell
-go get github.com/hashicorp/go-set/v2@latest
+go get github.com/hashicorp/go-set/v3@latest
 ```
 
 ```shell
-import "github.com/hashicorp/go-set/v2"
+import "github.com/hashicorp/go-set/v3"
 ```
 
 # Motivation

--- a/collection.go
+++ b/collection.go
@@ -202,14 +202,12 @@ func equalSet[T any](a, b Collection[T]) bool {
 	}
 
 	// look for any missing element
-	different := false
 	for item := range a.Items() {
 		if !b.Contains(item) {
-			different = true
-			return false // halt
+			return false
 		}
 	}
-	return !different
+	return true
 }
 
 func removeSet[T any](s, col Collection[T]) bool {
@@ -236,12 +234,12 @@ func subset[T any](a, b Collection[T]) bool {
 	if b.Size() > a.Size() {
 		return false
 	}
-	missing := false
+
 	for item := range b.Items() {
 		if !a.Contains(item) {
-			missing = true
-			return false // stop iteration
+			return false
 		}
 	}
-	return !missing
+
+	return true
 }

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
-module github.com/hashicorp/go-set/v2
+module github.com/hashicorp/go-set/v3
 
-go 1.21
+go 1.23
 
 require github.com/shoenig/test v1.8.2
 

--- a/hashset_test.go
+++ b/hashset_test.go
@@ -724,3 +724,17 @@ func TestHashSet_HashCode(t *testing.T) {
 	must.True(t, a.Contains(s2))
 	must.False(t, a.Contains(s3))
 }
+
+func TestHashSet_Items(t *testing.T) {
+	a := NewHashSet[*coded, int](0)
+	a.Insert(s1)
+	a.Insert(s2)
+	a.Insert(s3)
+
+	sum := 0
+	for element := range a.Items() {
+		sum += element.i
+	}
+
+	must.Eq(t, 6, sum)
+}

--- a/set.go
+++ b/set.go
@@ -8,6 +8,7 @@ package set
 
 import (
 	"fmt"
+	"iter"
 	"sort"
 )
 
@@ -89,12 +90,11 @@ func (s *Set[T]) InsertSlice(items []T) bool {
 // Return true if s was modified (at least one item of col was not already in s), false otherwise.
 func (s *Set[T]) InsertSet(col Collection[T]) bool {
 	modified := false
-	col.ForEach(func(item T) bool {
+	for item := range col.Items() {
 		if s.Insert(item) {
 			modified = true
 		}
-		return true
-	})
+	}
 	return modified
 }
 
@@ -295,13 +295,16 @@ func (s *Set[T]) UnmarshalJSON(data []byte) error {
 	return unmarshalJSON[T](s, data)
 }
 
-// ForEach iterates every element in s, applying the given visit function.
+// Items returns a generator function for iterating each element in s by using
+// the range keyword.
 //
-// If the visit returns false at any point, iteration is halted.
-func (s *Set[T]) ForEach(visit func(T) bool) {
-	for item := range s.items {
-		if !visit(item) {
-			return
+//	for element := range s.Items() { ... }
+func (s *Set[T]) Items() iter.Seq[T] {
+	return func(yield func(T) bool) {
+		for item := range s.items {
+			if !yield(item) {
+				return
+			}
 		}
 	}
 }

--- a/set_test.go
+++ b/set_test.go
@@ -5,7 +5,6 @@ package set
 
 import (
 	"fmt"
-	"sort"
 	"testing"
 
 	"github.com/shoenig/test/must"
@@ -750,16 +749,13 @@ func TestSet_EqualSliceSet(t *testing.T) {
 	})
 }
 
-func TestSet_ForEach(t *testing.T) {
-	s := From[int]([]int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9})
-	var result []int
-	evens := func(i int) bool {
-		if i%2 == 0 {
-			result = append(result, i)
-		}
-		return true
+func TestSet_Items(t *testing.T) {
+	s := From[int]([]int{1, 2, 3, 4, 5})
+
+	sum := 0
+	for element := range s.Items() {
+		sum += element
 	}
-	s.ForEach(evens)
-	sort.Ints(result)
-	must.Eq(t, []int{0, 2, 4, 6, 8}, result)
+
+	must.Eq(t, 15, sum)
 }

--- a/treeset_test.go
+++ b/treeset_test.go
@@ -1011,3 +1011,15 @@ func TestTreeSet_iterate2(t *testing.T) {
 	}
 	must.Nil(t, iter())
 }
+
+func TestTreeSet_Items(t *testing.T) {
+	ts := TreeSetFrom[int]([]int{2, 1, 4, 3, 5}, Compare[int])
+
+	exp := []int{1, 2, 3, 4, 5}
+	result := []int{}
+	for element := range ts.Items() {
+		result = append(result, element)
+	}
+
+	must.Eq(t, exp, result)
+}


### PR DESCRIPTION
Starting with `go1.23`, Go supports using `range` with custom user types
that satisfy interfaces of the `iter` package. We can make use of this
functionality for iterating over elements of each type of set.

```go
s := set.From([]int{2, 1, 1, 3})
for item := range s.Items() {
  fmt.Println(item)
}
```

This functionality replaces the need for the `ForEach` defined on each
set type, and so that method is removed. This means we need a v3 breaking
change for the release.

Closes #82
Part of #90 