### PR TITLE
v3: eleminate GoType and Compare types

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,11 +106,11 @@ implement an efficient hash function using a hash code based on prime multiples.
 
 The `go-set` package includes `TreeSet` for creating sorted sets. A `TreeSet` may
 be used with any type `T` as the comparison between elements is provided by implementing
-`CompareFunc[T]`. The `Compare[GoType]` helper provides a convenient implementation of
-`CompareFunc` for `builtin` types like `string` or `int`. A `TreeSet` is backed by
-an underlying balanced binary search tree, making operations like in-order traversal
-efficient, in addition to enabling functions like `Min()`, `Max()`, `TopK()`, and
-`BottomK()`.
+`CompareFunc[T]`. The standard library `cmp.Compare` function provides a convenient
+implementation of `CompareFunc` for `cmp.Ordered` types like `string` or `int`. A
+`TreeSet` is backed by an underlying balanced binary search tree, making operations
+like in-order traversal efficient, in addition to enabling functions like `Min()`,
+`Max()`, `TopK()`, and `BottomK()`.
 
 # Collection[T]
 
@@ -198,14 +198,10 @@ s.Insert(e1)
 
 Below are simple example usages of `TreeSet`
 
-(using the `Compare` helper to compare a built in `GoType`)
-
 ```go
 ts := NewTreeSet[int](Compare[int])
 ts.Insert(5)
 ```
-
-(using a custom `CompareFunc`)
 
 ```go
 type waypoint struct {
@@ -213,11 +209,12 @@ type waypoint struct {
     name     string
 }
 
-cmp := func(w1, w2 *waypoint) int {
+// compare implements CompareFunc
+compare := func(w1, w2 *waypoint) int {
     return w1.distance - w2.distance
 }
 
-ts := NewTreeSet[*waypoint](cmp)
+ts := NewTreeSet[*waypoint](compare)
 ts.Insert(&waypoint{distance: 42, name: "tango"})
 ts.Insert(&waypoint{distance: 13, name: "alpha"})
 ts.Insert(&waypoint{distance: 71, name: "xray"})

--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -4,6 +4,7 @@
 package set
 
 import (
+	"cmp"
 	"math/rand"
 	"sort"
 	"testing"
@@ -74,7 +75,7 @@ func BenchmarkHashSet_Insert(b *testing.B) {
 
 func BenchmarkTreeSet_Insert(b *testing.B) {
 	for _, tc := range cases {
-		ts := TreeSetFrom[int](random[int](tc.size), Compare[int])
+		ts := TreeSetFrom[int](random[int](tc.size), cmp.Compare[int])
 		b.Run(tc.name, func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 				ts.Insert(i)
@@ -125,7 +126,7 @@ func BenchmarkHashSet_Minimum(b *testing.B) {
 
 func BenchmarkTreeSet_Minimum(b *testing.B) {
 	for _, tc := range cases {
-		ts := TreeSetFrom[int](random[int](tc.size), Compare[int])
+		ts := TreeSetFrom[int](random[int](tc.size), cmp.Compare[int])
 		b.Run(tc.name, func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 				_ = ts.Min()
@@ -178,7 +179,7 @@ func BenchmarkHashSet_Contains(b *testing.B) {
 
 func BenchmarkTreeSet_Contains(b *testing.B) {
 	for _, tc := range cases {
-		ts := TreeSetFrom[int](random[int](tc.size), Compare[int])
+		ts := TreeSetFrom[int](random[int](tc.size), cmp.Compare[int])
 		b.Run(tc.name, func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 				_ = ts.Contains(i)

--- a/collection_test.go
+++ b/collection_test.go
@@ -4,6 +4,7 @@
 package set
 
 import (
+	"cmp"
 	"sort"
 	"strconv"
 	"testing"
@@ -37,11 +38,11 @@ func TestInsertSliceFunc(t *testing.T) {
 	})
 
 	t.Run("treeSet", func(t *testing.T) {
-		s := NewTreeSet[string](Compare[string])
+		s := NewTreeSet[string](cmp.Compare[string])
 		InsertSliceFunc[string](s, numbers, func(element int) string {
 			return strconv.Itoa(element)
 		})
-		invariants(t, s, Compare[string])
+		invariants(t, s, cmp.Compare[string])
 		must.SliceEqFunc(t, s.Slice(), []string{"1", "2", "3"}, func(a, b string) bool { return a == b })
 	})
 }
@@ -67,7 +68,7 @@ func TestSliceFunc(t *testing.T) {
 	})
 
 	t.Run("treeSet", func(t *testing.T) {
-		s := TreeSetFrom[int]([]int{1, 2, 3}, Compare[int])
+		s := TreeSetFrom[int]([]int{1, 2, 3}, cmp.Compare[int])
 		slice := SliceFunc[int](s, func(element int) string {
 			return strconv.Itoa(element)
 		})
@@ -105,7 +106,7 @@ func TestInsertSetFunc(t *testing.T) {
 		})
 
 		t.Run("set -> treeSet", func(t *testing.T) {
-			b := NewTreeSet[string](Compare[string])
+			b := NewTreeSet[string](cmp.Compare[string])
 			modified := InsertSetFunc[int, string](a, b, func(element int) string {
 				return strconv.Itoa(element)
 			})
@@ -154,7 +155,7 @@ func TestInsertSetFunc(t *testing.T) {
 		})
 
 		t.Run("hashSet -> treeSet", func(t *testing.T) {
-			b := NewTreeSet[int](Compare[int])
+			b := NewTreeSet[int](cmp.Compare[int])
 			modified := InsertSetFunc[*company, int](a, b, func(element *company) int {
 				return element.floor
 			})
@@ -174,7 +175,7 @@ func TestInsertSetFunc(t *testing.T) {
 	})
 
 	t.Run("treeSet", func(t *testing.T) {
-		a := TreeSetFrom[int]([]int{1, 2, 3}, Compare[int])
+		a := TreeSetFrom[int]([]int{1, 2, 3}, cmp.Compare[int])
 
 		t.Run("treeSet -> set", func(t *testing.T) {
 			b := New[string](3)
@@ -202,7 +203,7 @@ func TestInsertSetFunc(t *testing.T) {
 		})
 
 		t.Run("treeSet -> treeSet", func(t *testing.T) {
-			b := NewTreeSet[string](Compare[string])
+			b := NewTreeSet[string](cmp.Compare[string])
 			modified := InsertSetFunc[int, string](a, b, func(element int) string {
 				return strconv.Itoa(element)
 			})

--- a/examples_treeset_test.go
+++ b/examples_treeset_test.go
@@ -31,7 +31,7 @@ func ExampleCompare_contestant() {
 }
 
 func ExampleCmp_strings() {
-	s := NewTreeSet[string](Compare[string])
+	s := NewTreeSet[string](cmp.Compare[string])
 	s.Insert("red")
 	s.Insert("green")
 	s.Insert("blue")
@@ -47,7 +47,7 @@ func ExampleCmp_strings() {
 }
 
 func ExampleCmp_ints() {
-	s := NewTreeSet[int](Compare[int])
+	s := NewTreeSet[int](cmp.Compare[int])
 	s.Insert(50)
 	s.Insert(42)
 	s.Insert(100)
@@ -63,7 +63,7 @@ func ExampleCmp_ints() {
 }
 
 func ExampleTreeSet_Insert() {
-	s := TreeSetFrom[string]([]string{}, Compare[string])
+	s := TreeSetFrom[string]([]string{}, cmp.Compare[string])
 
 	fmt.Println(s)
 
@@ -78,7 +78,7 @@ func ExampleTreeSet_Insert() {
 }
 
 func ExampleTreeSet_InsertSlice() {
-	s := TreeSetFrom[string]([]string{}, Compare[string])
+	s := TreeSetFrom[string]([]string{}, cmp.Compare[string])
 
 	fmt.Println(s)
 
@@ -91,8 +91,8 @@ func ExampleTreeSet_InsertSlice() {
 }
 
 func ExampleTreeSet_InsertSet() {
-	s1 := TreeSetFrom[string]([]string{"red", "green"}, Compare[string])
-	s2 := TreeSetFrom[string]([]string{"green", "blue"}, Compare[string])
+	s1 := TreeSetFrom[string]([]string{"red", "green"}, cmp.Compare[string])
+	s2 := TreeSetFrom[string]([]string{"green", "blue"}, cmp.Compare[string])
 
 	fmt.Println(s1)
 	fmt.Println(s2)
@@ -108,7 +108,7 @@ func ExampleTreeSet_InsertSet() {
 }
 
 func ExampleTreeSet_Remove() {
-	s := TreeSetFrom[string]([]string{"red", "green", "blue"}, Compare[string])
+	s := TreeSetFrom[string]([]string{"red", "green", "blue"}, cmp.Compare[string])
 
 	fmt.Println(s)
 
@@ -125,7 +125,7 @@ func ExampleTreeSet_Remove() {
 }
 
 func ExampleTreeSet_RemoveSlice() {
-	s := TreeSetFrom[string]([]string{"red", "green", "blue"}, Compare[string])
+	s := TreeSetFrom[string]([]string{"red", "green", "blue"}, cmp.Compare[string])
 
 	fmt.Println(s)
 
@@ -142,8 +142,8 @@ func ExampleTreeSet_RemoveSlice() {
 }
 
 func ExampleTreeSet_RemoveSet() {
-	s1 := TreeSetFrom[string]([]string{"a", "b", "c", "d", "e", "f"}, Compare[string])
-	s2 := TreeSetFrom[string]([]string{"e", "z", "a"}, Compare[string])
+	s1 := TreeSetFrom[string]([]string{"a", "b", "c", "d", "e", "f"}, cmp.Compare[string])
+	s2 := TreeSetFrom[string]([]string{"e", "z", "a"}, cmp.Compare[string])
 
 	fmt.Println(s1)
 	fmt.Println(s2)
@@ -159,7 +159,7 @@ func ExampleTreeSet_RemoveSet() {
 }
 
 func ExampleTreeSet_RemoveFunc() {
-	s := TreeSetFrom[int](ints(20), Compare[int])
+	s := TreeSetFrom[int](ints(20), cmp.Compare[int])
 
 	fmt.Println(s)
 
@@ -176,7 +176,7 @@ func ExampleTreeSet_RemoveFunc() {
 }
 
 func ExampleTreeSet_Contains() {
-	s := TreeSetFrom[string]([]string{"red", "green", "blue"}, Compare[string])
+	s := TreeSetFrom[string]([]string{"red", "green", "blue"}, cmp.Compare[string])
 
 	fmt.Println(s.Contains("green"))
 	fmt.Println(s.Contains("orange"))
@@ -187,7 +187,7 @@ func ExampleTreeSet_Contains() {
 }
 
 func ExampleTreeSet_ContainsSlice() {
-	s := TreeSetFrom[string]([]string{"red", "green", "blue"}, Compare[string])
+	s := TreeSetFrom[string]([]string{"red", "green", "blue"}, cmp.Compare[string])
 
 	fmt.Println(s.ContainsSlice([]string{"red", "green"}))
 	fmt.Println(s.ContainsSlice([]string{"red", "orange"}))
@@ -198,9 +198,9 @@ func ExampleTreeSet_ContainsSlice() {
 }
 
 func ExampleTreeSet_Subset() {
-	s1 := TreeSetFrom[string]([]string{"a", "b", "c", "d", "e"}, Compare[string])
-	s2 := TreeSetFrom[string]([]string{"b", "d"}, Compare[string])
-	s3 := TreeSetFrom[string]([]string{"a", "z"}, Compare[string])
+	s1 := TreeSetFrom[string]([]string{"a", "b", "c", "d", "e"}, cmp.Compare[string])
+	s2 := TreeSetFrom[string]([]string{"b", "d"}, cmp.Compare[string])
+	s3 := TreeSetFrom[string]([]string{"a", "z"}, cmp.Compare[string])
 
 	fmt.Println(s1.Subset(s2))
 	fmt.Println(s1.Subset(s3))
@@ -211,7 +211,7 @@ func ExampleTreeSet_Subset() {
 }
 
 func ExampleTreeSet_Size() {
-	s := TreeSetFrom[string]([]string{"red", "green", "blue"}, Compare[string])
+	s := TreeSetFrom[string]([]string{"red", "green", "blue"}, cmp.Compare[string])
 
 	fmt.Println(s.Size())
 
@@ -220,7 +220,7 @@ func ExampleTreeSet_Size() {
 }
 
 func ExampleTreeSet_Empty() {
-	s := TreeSetFrom[string]([]string{}, Compare[string])
+	s := TreeSetFrom[string]([]string{}, cmp.Compare[string])
 
 	fmt.Println(s.Empty())
 
@@ -234,9 +234,9 @@ func ExampleTreeSet_Empty() {
 }
 
 func ExampleTreeSet_Union() {
-	s := TreeSetFrom[int]([]int{1, 2, 3, 4, 5}, Compare[int])
-	t := TreeSetFrom[int]([]int{5, 4, 3, 2, 1}, Compare[int])
-	f := TreeSetFrom[int]([]int{1, 3, 5, 7, 9}, Compare[int])
+	s := TreeSetFrom[int]([]int{1, 2, 3, 4, 5}, cmp.Compare[int])
+	t := TreeSetFrom[int]([]int{5, 4, 3, 2, 1}, cmp.Compare[int])
+	f := TreeSetFrom[int]([]int{1, 3, 5, 7, 9}, cmp.Compare[int])
 
 	fmt.Println(s.Union(t))
 	fmt.Println(s.Union(f))
@@ -247,9 +247,9 @@ func ExampleTreeSet_Union() {
 }
 
 func ExampleTreeSet_Difference() {
-	s := TreeSetFrom[int]([]int{1, 2, 3, 4, 5}, Compare[int])
-	t := TreeSetFrom[int]([]int{5, 4, 3, 2, 1}, Compare[int])
-	f := TreeSetFrom[int]([]int{1, 3, 5, 7, 9}, Compare[int])
+	s := TreeSetFrom[int]([]int{1, 2, 3, 4, 5}, cmp.Compare[int])
+	t := TreeSetFrom[int]([]int{5, 4, 3, 2, 1}, cmp.Compare[int])
+	f := TreeSetFrom[int]([]int{1, 3, 5, 7, 9}, cmp.Compare[int])
 
 	fmt.Println(s.Difference(t))
 	fmt.Println(s.Difference(f))
@@ -260,9 +260,9 @@ func ExampleTreeSet_Difference() {
 }
 
 func ExampleTreeSet_Intersect() {
-	s := TreeSetFrom[int]([]int{1, 2, 3, 4, 5}, Compare[int])
-	t := TreeSetFrom[int]([]int{5, 4, 3, 2, 1}, Compare[int])
-	f := TreeSetFrom[int]([]int{1, 3, 5, 7, 9}, Compare[int])
+	s := TreeSetFrom[int]([]int{1, 2, 3, 4, 5}, cmp.Compare[int])
+	t := TreeSetFrom[int]([]int{5, 4, 3, 2, 1}, cmp.Compare[int])
+	f := TreeSetFrom[int]([]int{1, 3, 5, 7, 9}, cmp.Compare[int])
 
 	fmt.Println(s.Intersect(t))
 	fmt.Println(s.Intersect(f))
@@ -273,9 +273,9 @@ func ExampleTreeSet_Intersect() {
 }
 
 func ExampleTreeSet_Equal() {
-	s := TreeSetFrom[int]([]int{1, 2, 3, 4, 5}, Compare[int])
-	t := TreeSetFrom[int]([]int{5, 4, 3, 2, 1}, Compare[int])
-	f := TreeSetFrom[int]([]int{1, 3, 5, 7, 9}, Compare[int])
+	s := TreeSetFrom[int]([]int{1, 2, 3, 4, 5}, cmp.Compare[int])
+	t := TreeSetFrom[int]([]int{5, 4, 3, 2, 1}, cmp.Compare[int])
+	f := TreeSetFrom[int]([]int{1, 3, 5, 7, 9}, cmp.Compare[int])
 
 	fmt.Println(s.Equal(t))
 	fmt.Println(s.Equal(f))
@@ -286,7 +286,7 @@ func ExampleTreeSet_Equal() {
 }
 
 func ExampleTreeSet_EqualSlice() {
-	t := TreeSetFrom[int]([]int{5, 4, 3, 2, 1}, Compare[int])
+	t := TreeSetFrom[int]([]int{5, 4, 3, 2, 1}, cmp.Compare[int])
 
 	fmt.Println(t.EqualSlice([]int{1, 2, 3, 4, 5}))
 	fmt.Println(t.EqualSlice([]int{1, 1, 2, 3, 4, 5}))
@@ -299,7 +299,7 @@ func ExampleTreeSet_EqualSlice() {
 }
 
 func ExampleTreeSet_EqualSliceSet() {
-	t := TreeSetFrom[int]([]int{5, 4, 3, 2, 1}, Compare[int])
+	t := TreeSetFrom[int]([]int{5, 4, 3, 2, 1}, cmp.Compare[int])
 
 	fmt.Println(t.EqualSliceSet([]int{1, 2, 3, 4, 5}))
 	fmt.Println(t.EqualSliceSet([]int{1, 1, 2, 3, 4, 5}))
@@ -312,7 +312,7 @@ func ExampleTreeSet_EqualSliceSet() {
 }
 
 func ExampleTreeSet_Copy() {
-	s := TreeSetFrom[int]([]int{1, 2, 3, 4, 5}, Compare[int])
+	s := TreeSetFrom[int]([]int{1, 2, 3, 4, 5}, cmp.Compare[int])
 	c := s.Copy()
 	s.Remove(2)
 	s.Remove(4)
@@ -326,7 +326,7 @@ func ExampleTreeSet_Copy() {
 }
 
 func ExampleTreeSet_Slice() {
-	s := TreeSetFrom[int]([]int{1, 2, 3, 4, 5}, Compare[int])
+	s := TreeSetFrom[int]([]int{1, 2, 3, 4, 5}, cmp.Compare[int])
 	slice := s.Slice()
 
 	fmt.Println(slice)
@@ -338,7 +338,7 @@ func ExampleTreeSet_Slice() {
 }
 
 func ExampleTreeSet_String() {
-	s := TreeSetFrom[int]([]int{1, 2, 3, 4, 5}, Compare[int])
+	s := TreeSetFrom[int]([]int{1, 2, 3, 4, 5}, cmp.Compare[int])
 
 	fmt.Println(s.String() == "[1 2 3 4 5]")
 
@@ -347,7 +347,7 @@ func ExampleTreeSet_String() {
 }
 
 func ExampleTreeSet_Min() {
-	s := TreeSetFrom[int]([]int{1, 2, 3, 4, 5}, Compare[int])
+	s := TreeSetFrom[int]([]int{1, 2, 3, 4, 5}, cmp.Compare[int])
 	r := TreeSetFrom[int]([]int{1, 2, 3, 4, 5}, func(a int, b int) int {
 		return b - a
 	})
@@ -361,7 +361,7 @@ func ExampleTreeSet_Min() {
 }
 
 func ExampleTreeSet_Max() {
-	s := TreeSetFrom[int]([]int{1, 2, 3, 4, 5}, Compare[int])
+	s := TreeSetFrom[int]([]int{1, 2, 3, 4, 5}, cmp.Compare[int])
 	r := TreeSetFrom[int]([]int{1, 2, 3, 4, 5}, func(a int, b int) int {
 		return b - a
 	})
@@ -375,7 +375,7 @@ func ExampleTreeSet_Max() {
 }
 
 func ExampleTreeSet_TopK() {
-	s := TreeSetFrom[int]([]int{1, 2, 3, 4, 5}, Compare[int])
+	s := TreeSetFrom[int]([]int{1, 2, 3, 4, 5}, cmp.Compare[int])
 
 	fmt.Println(s.TopK(0))
 	fmt.Println(s.TopK(1))
@@ -390,7 +390,7 @@ func ExampleTreeSet_TopK() {
 }
 
 func ExampleTreeSet_BottomK() {
-	s := TreeSetFrom[int]([]int{1, 2, 3, 4, 5}, Compare[int])
+	s := TreeSetFrom[int]([]int{1, 2, 3, 4, 5}, cmp.Compare[int])
 
 	fmt.Println(s.BottomK(0))
 	fmt.Println(s.BottomK(1))
@@ -405,7 +405,7 @@ func ExampleTreeSet_BottomK() {
 }
 
 func ExampleTreeSet_FirstAbove() {
-	s := TreeSetFrom[int]([]int{1, 2, 3, 4, 5}, Compare[int])
+	s := TreeSetFrom[int]([]int{1, 2, 3, 4, 5}, cmp.Compare[int])
 
 	fmt.Println(s.FirstAbove(3))
 	fmt.Println(s.FirstAbove(5))
@@ -418,7 +418,7 @@ func ExampleTreeSet_FirstAbove() {
 }
 
 func ExampleTreeSet_FirstAboveEqual() {
-	s := TreeSetFrom[int]([]int{1, 2, 3, 4, 5}, Compare[int])
+	s := TreeSetFrom[int]([]int{1, 2, 3, 4, 5}, cmp.Compare[int])
 
 	fmt.Println(s.FirstAboveEqual(3))
 	fmt.Println(s.FirstAboveEqual(5))
@@ -431,7 +431,7 @@ func ExampleTreeSet_FirstAboveEqual() {
 }
 
 func ExampleTreeSet_Above() {
-	s := TreeSetFrom[int]([]int{1, 2, 3, 4, 5}, Compare[int])
+	s := TreeSetFrom[int]([]int{1, 2, 3, 4, 5}, cmp.Compare[int])
 
 	fmt.Println(s.Above(3))
 	fmt.Println(s.Above(5))
@@ -444,7 +444,7 @@ func ExampleTreeSet_Above() {
 }
 
 func ExampleTreeSet_AboveEqual() {
-	s := TreeSetFrom[int]([]int{1, 2, 3, 4, 5}, Compare[int])
+	s := TreeSetFrom[int]([]int{1, 2, 3, 4, 5}, cmp.Compare[int])
 
 	fmt.Println(s.AboveEqual(3))
 	fmt.Println(s.AboveEqual(5))
@@ -457,7 +457,7 @@ func ExampleTreeSet_AboveEqual() {
 }
 
 func ExampleTreeSet_FirstBelow() {
-	s := TreeSetFrom[int]([]int{1, 2, 3, 4, 5}, Compare[int])
+	s := TreeSetFrom[int]([]int{1, 2, 3, 4, 5}, cmp.Compare[int])
 
 	fmt.Println(s.FirstBelow(1))
 	fmt.Println(s.FirstBelow(3))
@@ -470,7 +470,7 @@ func ExampleTreeSet_FirstBelow() {
 }
 
 func ExampleTreeSet_FirstBelowEqual() {
-	s := TreeSetFrom[int]([]int{1, 2, 3, 4, 5}, Compare[int])
+	s := TreeSetFrom[int]([]int{1, 2, 3, 4, 5}, cmp.Compare[int])
 
 	fmt.Println(s.FirstBelowEqual(1))
 	fmt.Println(s.FirstBelowEqual(3))
@@ -483,7 +483,7 @@ func ExampleTreeSet_FirstBelowEqual() {
 }
 
 func ExampleTreeSet_Below() {
-	s := TreeSetFrom[int]([]int{1, 2, 3, 4, 5}, Compare[int])
+	s := TreeSetFrom[int]([]int{1, 2, 3, 4, 5}, cmp.Compare[int])
 
 	fmt.Println(s.Below(1))
 	fmt.Println(s.Below(3))
@@ -496,7 +496,7 @@ func ExampleTreeSet_Below() {
 }
 
 func ExampleTreeSet_BelowEqual() {
-	s := TreeSetFrom[int]([]int{1, 2, 3, 4, 5}, Compare[int])
+	s := TreeSetFrom[int]([]int{1, 2, 3, 4, 5}, cmp.Compare[int])
 
 	fmt.Println(s.BelowEqual(1))
 	fmt.Println(s.BelowEqual(3))

--- a/serialization_test.go
+++ b/serialization_test.go
@@ -4,6 +4,7 @@
 package set
 
 import (
+	"cmp"
 	"encoding/json"
 	"testing"
 
@@ -42,7 +43,7 @@ func TestSerialization(t *testing.T) {
 	})
 
 	t.Run("TreeSet", func(t *testing.T) {
-		set := NewTreeSet[int](Compare[int])
+		set := NewTreeSet[int](cmp.Compare[int])
 		set.InsertSlice([]int{10, 3, 13})
 		bs, err := json.Marshal(set)
 		must.NoError(t, err)
@@ -50,7 +51,7 @@ func TestSerialization(t *testing.T) {
 		must.StrContains(t, string(bs), "3")
 		must.StrContains(t, string(bs), "13")
 
-		dstSet := NewTreeSet[int](Compare[int])
+		dstSet := NewTreeSet[int](cmp.Compare[int])
 		err = json.Unmarshal(bs, dstSet)
 		must.NoError(t, err)
 		must.Eq(t, set.Slice(), dstSet.Slice())

--- a/treeset.go
+++ b/treeset.go
@@ -14,28 +14,10 @@ import (
 // < 0 if the first parameter is less than the second parameter
 // 0 if the two parameters are equal
 // > 0 if the first parameters is greater than the second parameter
-type CompareFunc[T any] func(T, T) int
-
-// GoType represents a builtin type to Go. These types can be compared using
-// the CompareFunc[GoType] function.
-type GoType interface {
-	~string | ~int | ~uint | ~int64 | ~uint64 | ~int32 | ~uint32 | ~int16 | ~uint16 | ~int8 | ~uint8
-}
-
-// Compare is a convenience implementation of CompareFunc[GoType] that can be
-// used for comparison of types built-in to Go.
 //
-// Common to use with string, int, uint, etc.
-func Compare[T GoType](x, y T) int {
-	switch {
-	case x < y:
-		return -1
-	case x > y:
-		return 1
-	default:
-		return 0
-	}
-}
+// Often T will be a type that satisfies cmp.Ordered, and can CompareFunc can
+// be implemented by using cmp.Compare.
+type CompareFunc[T any] func(T, T) int
 
 // TreeSet provides a generic sortable set implementation for Go.
 // Enables fast storage and retrieval of ordered information. Most effective

--- a/treeset.go
+++ b/treeset.go
@@ -15,7 +15,7 @@ import (
 // 0 if the two parameters are equal
 // > 0 if the first parameters is greater than the second parameter
 //
-// Often T will be a type that satisfies cmp.Ordered, and can CompareFunc can
+// Often T will be a type that satisfies cmp.Ordered, and CompareFunc can
 // be implemented by using cmp.Compare.
 type CompareFunc[T any] func(T, T) int
 

--- a/treeset_test.go
+++ b/treeset_test.go
@@ -4,6 +4,7 @@
 package set
 
 import (
+	"cmp"
 	"fmt"
 	"math/rand"
 	"strings"
@@ -25,7 +26,7 @@ func (t *token) String() string {
 }
 
 func compareTokens(a, b *token) int {
-	return Compare(a.id, b.id)
+	return cmp.Compare(a.id, b.id)
 }
 
 var (
@@ -47,18 +48,18 @@ func TestNewTreeSet(t *testing.T) {
 
 func TestTreeSetFrom(t *testing.T) {
 	s := shuffle(ints(10))
-	ts := TreeSetFrom[int](s, Compare[int])
+	ts := TreeSetFrom[int](s, cmp.Compare[int])
 	must.NotEmpty(t, ts)
 }
 
 func TestTreeSet_Empty(t *testing.T) {
 	t.Run("empty", func(t *testing.T) {
-		ts := NewTreeSet[int](Compare[int])
+		ts := NewTreeSet[int](cmp.Compare[int])
 		must.Empty(t, ts)
 	})
 
 	t.Run("not empty", func(t *testing.T) {
-		ts := NewTreeSet[int](Compare[int])
+		ts := NewTreeSet[int](cmp.Compare[int])
 		ts.Insert(1)
 		must.NotEmpty(t, ts)
 	})
@@ -66,16 +67,16 @@ func TestTreeSet_Empty(t *testing.T) {
 
 func TestTreeSet_Size(t *testing.T) {
 	t.Run("empty", func(t *testing.T) {
-		ts := NewTreeSet[int](Compare[int])
+		ts := NewTreeSet[int](cmp.Compare[int])
 		must.Size(t, 0, ts)
 	})
 	t.Run("one", func(t *testing.T) {
-		ts := NewTreeSet[int](Compare[int])
+		ts := NewTreeSet[int](cmp.Compare[int])
 		ts.Insert(42)
 		must.Size(t, 1, ts)
 	})
 	t.Run("ten", func(t *testing.T) {
-		ts := NewTreeSet[int](Compare[int])
+		ts := NewTreeSet[int](cmp.Compare[int])
 		s := shuffle(ints(10))
 		for i := 0; i < len(s); i++ {
 			ts.Insert(s[i])
@@ -122,7 +123,7 @@ func TestTreeSet_Insert_token(t *testing.T) {
 }
 
 func TestTreeSet_Insert_int(t *testing.T) {
-	cmp := Compare[int]
+	cmp := cmp.Compare[int]
 	ts := NewTreeSet[int](cmp)
 
 	numbers := ints(size)
@@ -138,7 +139,7 @@ func TestTreeSet_Insert_int(t *testing.T) {
 }
 
 func TestTreeSet_InsertSlice(t *testing.T) {
-	cmp := Compare[int]
+	cmp := cmp.Compare[int]
 
 	numbers := ints(size)
 	random := shuffle(numbers)
@@ -150,7 +151,7 @@ func TestTreeSet_InsertSlice(t *testing.T) {
 }
 
 func TestTreeSet_InsertSet(t *testing.T) {
-	cmp := Compare[int]
+	cmp := cmp.Compare[int]
 
 	ts1 := TreeSetFrom[int]([]int{1, 3, 5, 7, 9}, cmp)
 	ts2 := TreeSetFrom[int]([]int{1, 2, 3}, cmp)
@@ -161,7 +162,7 @@ func TestTreeSet_InsertSet(t *testing.T) {
 }
 
 func TestTreeSet_Remove_int(t *testing.T) {
-	cmp := Compare[int]
+	cmp := cmp.Compare[int]
 	ts := NewTreeSet[int](cmp)
 
 	numbers := ints(size)
@@ -191,7 +192,7 @@ func TestTreeSet_Remove_int(t *testing.T) {
 }
 
 func TestTreeSet_RemoveSlice(t *testing.T) {
-	cmp := Compare[int]
+	cmp := cmp.Compare[int]
 	ts := NewTreeSet[int](cmp)
 
 	numbers := ints(size)
@@ -203,7 +204,7 @@ func TestTreeSet_RemoveSlice(t *testing.T) {
 }
 
 func TestTreeSet_RemoveSet(t *testing.T) {
-	cmp := Compare[int]
+	cmp := cmp.Compare[int]
 
 	ts1 := NewTreeSet[int](cmp)
 	ts2 := NewTreeSet[int](cmp)
@@ -221,7 +222,7 @@ func TestTreeSet_RemoveSet(t *testing.T) {
 }
 
 func TestTreeSet_RemoveFunc(t *testing.T) {
-	cmp := Compare[byte]
+	cmp := cmp.Compare[byte]
 
 	ts := TreeSetFrom[byte]([]byte{
 		'a', 'b', '1', 'c', '2', 'd',
@@ -238,12 +239,12 @@ func TestTreeSet_RemoveFunc(t *testing.T) {
 
 func TestTreeSet_Contains(t *testing.T) {
 	t.Run("empty", func(t *testing.T) {
-		ts := NewTreeSet[int](Compare[int])
+		ts := NewTreeSet[int](cmp.Compare[int])
 		must.False(t, ts.Contains(42))
 	})
 
 	t.Run("exists", func(t *testing.T) {
-		ts := TreeSetFrom[int]([]int{1, 2, 3, 4, 5}, Compare[int])
+		ts := TreeSetFrom[int]([]int{1, 2, 3, 4, 5}, cmp.Compare[int])
 		must.Contains[int](t, 1, ts)
 		must.Contains[int](t, 2, ts)
 		must.Contains[int](t, 3, ts)
@@ -252,7 +253,7 @@ func TestTreeSet_Contains(t *testing.T) {
 	})
 
 	t.Run("absent", func(t *testing.T) {
-		ts := TreeSetFrom[int]([]int{1, 2, 3, 4, 5}, Compare[int])
+		ts := TreeSetFrom[int]([]int{1, 2, 3, 4, 5}, cmp.Compare[int])
 		must.NotContains[int](t, 0, ts)
 		must.NotContains[int](t, 6, ts)
 	})
@@ -260,18 +261,18 @@ func TestTreeSet_Contains(t *testing.T) {
 
 func TestTreeSet_ContainsSlice(t *testing.T) {
 	t.Run("empty", func(t *testing.T) {
-		ts := NewTreeSet[int](Compare[int])
+		ts := NewTreeSet[int](cmp.Compare[int])
 		must.False(t, ts.ContainsSlice([]int{42, 43, 44}))
 	})
 
 	t.Run("exists", func(t *testing.T) {
-		ts := TreeSetFrom[int]([]int{1, 2, 3, 4, 5}, Compare[int])
+		ts := TreeSetFrom[int]([]int{1, 2, 3, 4, 5}, cmp.Compare[int])
 		must.True(t, ts.ContainsSlice([]int{2, 1, 3}))
 		must.True(t, ts.ContainsSlice([]int{5, 4, 3, 2, 1}))
 	})
 
 	t.Run("absent", func(t *testing.T) {
-		ts := TreeSetFrom[int]([]int{1, 2, 3, 4, 5}, Compare[int])
+		ts := TreeSetFrom[int]([]int{1, 2, 3, 4, 5}, cmp.Compare[int])
 		must.False(t, ts.ContainsSlice([]int{6, 7, 8}))
 		must.False(t, ts.ContainsSlice([]int{4, 5, 6}))
 	})
@@ -279,141 +280,141 @@ func TestTreeSet_ContainsSlice(t *testing.T) {
 
 func TestTreeSet_Subset(t *testing.T) {
 	t.Run("empty empty", func(t *testing.T) {
-		t1 := NewTreeSet[int](Compare[int])
-		t2 := NewTreeSet[int](Compare[int])
+		t1 := NewTreeSet[int](cmp.Compare[int])
+		t2 := NewTreeSet[int](cmp.Compare[int])
 		must.True(t, t1.Subset(t2))
 	})
 
 	t.Run("empty full", func(t *testing.T) {
-		t1 := NewTreeSet[int](Compare[int])
-		t2 := TreeSetFrom[int]([]int{1, 2, 3}, Compare[int])
+		t1 := NewTreeSet[int](cmp.Compare[int])
+		t2 := TreeSetFrom[int]([]int{1, 2, 3}, cmp.Compare[int])
 		must.False(t, t1.Subset(t2))
 	})
 
 	t.Run("full empty", func(t *testing.T) {
-		t1 := NewTreeSet[int](Compare[int])
-		t2 := TreeSetFrom[int]([]int{1, 2, 3}, Compare[int])
+		t1 := NewTreeSet[int](cmp.Compare[int])
+		t2 := TreeSetFrom[int]([]int{1, 2, 3}, cmp.Compare[int])
 		must.True(t, t2.Subset(t1))
 	})
 
 	t.Run("same", func(t *testing.T) {
-		t1 := TreeSetFrom[int]([]int{2, 1, 3}, Compare[int])
-		t2 := TreeSetFrom[int]([]int{1, 2, 3}, Compare[int])
+		t1 := TreeSetFrom[int]([]int{2, 1, 3}, cmp.Compare[int])
+		t2 := TreeSetFrom[int]([]int{1, 2, 3}, cmp.Compare[int])
 		must.True(t, t1.Subset(t2))
 		must.True(t, t2.Subset(t1))
 	})
 
 	t.Run("subset", func(t *testing.T) {
-		t1 := TreeSetFrom[int]([]int{2, 1, 3}, Compare[int])
-		t2 := TreeSetFrom[int]([]int{5, 4, 1, 2, 3}, Compare[int])
+		t1 := TreeSetFrom[int]([]int{2, 1, 3}, cmp.Compare[int])
+		t2 := TreeSetFrom[int]([]int{5, 4, 1, 2, 3}, cmp.Compare[int])
 		must.False(t, t1.Subset(t2))
 	})
 
 	t.Run("superset", func(t *testing.T) {
-		t1 := TreeSetFrom[int]([]int{9, 7, 8, 5, 4, 2, 1, 3}, Compare[int])
-		t2 := TreeSetFrom[int]([]int{5, 1, 2, 8, 3}, Compare[int])
+		t1 := TreeSetFrom[int]([]int{9, 7, 8, 5, 4, 2, 1, 3}, cmp.Compare[int])
+		t2 := TreeSetFrom[int]([]int{5, 1, 2, 8, 3}, cmp.Compare[int])
 		must.True(t, t1.Subset(t2))
 	})
 
 	t.Run("diff set", func(t *testing.T) {
-		t1 := TreeSetFrom[int]([]int{1, 2, 3, 4, 5}, Compare[int])
-		t2 := TreeSetFrom[int]([]int{6, 7, 8, 9, 10}, Compare[int])
+		t1 := TreeSetFrom[int]([]int{1, 2, 3, 4, 5}, cmp.Compare[int])
+		t2 := TreeSetFrom[int]([]int{6, 7, 8, 9, 10}, cmp.Compare[int])
 		must.False(t, t1.Subset(t2))
 	})
 
 	t.Run("exhaust", func(t *testing.T) {
-		s1 := TreeSetFrom[string]([]string{"a", "b", "c", "d", "e"}, Compare[string])
-		s2 := TreeSetFrom[string]([]string{"a", "z"}, Compare[string])
+		s1 := TreeSetFrom[string]([]string{"a", "b", "c", "d", "e"}, cmp.Compare[string])
+		s2 := TreeSetFrom[string]([]string{"a", "z"}, cmp.Compare[string])
 		must.False(t, s1.Subset(s2))
 	})
 }
 
 func TestTreeSet_ProperSubset(t *testing.T) {
 	t.Run("empty empty", func(t *testing.T) {
-		t1 := NewTreeSet[int](Compare[int])
-		t2 := NewTreeSet[int](Compare[int])
+		t1 := NewTreeSet[int](cmp.Compare[int])
+		t2 := NewTreeSet[int](cmp.Compare[int])
 		must.False(t, t1.ProperSubset(t2))
 	})
 
 	t.Run("empty full", func(t *testing.T) {
-		t1 := NewTreeSet[int](Compare[int])
-		t2 := TreeSetFrom[int]([]int{1, 2, 3}, Compare[int])
+		t1 := NewTreeSet[int](cmp.Compare[int])
+		t2 := TreeSetFrom[int]([]int{1, 2, 3}, cmp.Compare[int])
 		must.False(t, t1.ProperSubset(t2))
 	})
 
 	t.Run("full empty", func(t *testing.T) {
-		t1 := NewTreeSet[int](Compare[int])
-		t2 := TreeSetFrom[int]([]int{1, 2, 3}, Compare[int])
+		t1 := NewTreeSet[int](cmp.Compare[int])
+		t2 := TreeSetFrom[int]([]int{1, 2, 3}, cmp.Compare[int])
 		must.True(t, t2.ProperSubset(t1))
 	})
 
 	t.Run("same", func(t *testing.T) {
-		t1 := TreeSetFrom[int]([]int{2, 1, 3}, Compare[int])
-		t2 := TreeSetFrom[int]([]int{1, 2, 3}, Compare[int])
+		t1 := TreeSetFrom[int]([]int{2, 1, 3}, cmp.Compare[int])
+		t2 := TreeSetFrom[int]([]int{1, 2, 3}, cmp.Compare[int])
 		must.False(t, t1.ProperSubset(t2))
 		must.False(t, t2.ProperSubset(t1))
 	})
 
 	t.Run("subset", func(t *testing.T) {
-		t1 := TreeSetFrom[int]([]int{2, 1, 3}, Compare[int])
-		t2 := TreeSetFrom[int]([]int{5, 4, 1, 2, 3}, Compare[int])
+		t1 := TreeSetFrom[int]([]int{2, 1, 3}, cmp.Compare[int])
+		t2 := TreeSetFrom[int]([]int{5, 4, 1, 2, 3}, cmp.Compare[int])
 		must.False(t, t1.ProperSubset(t2))
 	})
 
 	t.Run("superset", func(t *testing.T) {
-		t1 := TreeSetFrom[int]([]int{9, 7, 8, 5, 4, 2, 1, 3}, Compare[int])
-		t2 := TreeSetFrom[int]([]int{5, 1, 2, 8, 3}, Compare[int])
+		t1 := TreeSetFrom[int]([]int{9, 7, 8, 5, 4, 2, 1, 3}, cmp.Compare[int])
+		t2 := TreeSetFrom[int]([]int{5, 1, 2, 8, 3}, cmp.Compare[int])
 		must.True(t, t1.ProperSubset(t2))
 	})
 
 	t.Run("diff set", func(t *testing.T) {
-		t1 := TreeSetFrom[int]([]int{1, 2, 3, 4, 5}, Compare[int])
-		t2 := TreeSetFrom[int]([]int{6, 7, 8, 9, 10}, Compare[int])
+		t1 := TreeSetFrom[int]([]int{1, 2, 3, 4, 5}, cmp.Compare[int])
+		t2 := TreeSetFrom[int]([]int{6, 7, 8, 9, 10}, cmp.Compare[int])
 		must.False(t, t1.ProperSubset(t2))
 	})
 
 	t.Run("exhaust", func(t *testing.T) {
-		s1 := TreeSetFrom[string]([]string{"a", "b", "c", "d", "e"}, Compare[string])
-		s2 := TreeSetFrom[string]([]string{"a", "z"}, Compare[string])
+		s1 := TreeSetFrom[string]([]string{"a", "b", "c", "d", "e"}, cmp.Compare[string])
+		s2 := TreeSetFrom[string]([]string{"a", "z"}, cmp.Compare[string])
 		must.False(t, s1.ProperSubset(s2))
 	})
 }
 
 func TestTreeSet_Union(t *testing.T) {
 	t.Run("empty empty", func(t *testing.T) {
-		t1 := TreeSetFrom[int](nil, Compare[int])
-		t2 := TreeSetFrom[int](nil, Compare[int])
+		t1 := TreeSetFrom[int](nil, cmp.Compare[int])
+		t2 := TreeSetFrom[int](nil, cmp.Compare[int])
 		result := t1.Union(t2)
 		must.Empty(t, result)
 	})
 
 	t.Run("empty full", func(t *testing.T) {
-		t1 := TreeSetFrom[int](nil, Compare[int])
-		t2 := TreeSetFrom[int]([]int{3, 1, 2}, Compare[int])
+		t1 := TreeSetFrom[int](nil, cmp.Compare[int])
+		t2 := TreeSetFrom[int]([]int{3, 1, 2}, cmp.Compare[int])
 		result := t1.Union(t2)
 		must.NotEmpty(t, result)
 		must.Eq(t, []int{1, 2, 3}, result.Slice())
 	})
 
 	t.Run("full empty", func(t *testing.T) {
-		t1 := TreeSetFrom[int]([]int{2, 3, 1}, Compare[int])
-		t2 := TreeSetFrom[int](nil, Compare[int])
+		t1 := TreeSetFrom[int]([]int{2, 3, 1}, cmp.Compare[int])
+		t2 := TreeSetFrom[int](nil, cmp.Compare[int])
 		result := t1.Union(t2)
 		must.NotEmpty(t, result)
 		must.Eq(t, []int{1, 2, 3}, result.Slice())
 	})
 
 	t.Run("subset", func(t *testing.T) {
-		t1 := TreeSetFrom[int]([]int{2, 3, 1}, Compare[int])
-		t2 := TreeSetFrom[int]([]int{2}, Compare[int])
+		t1 := TreeSetFrom[int]([]int{2, 3, 1}, cmp.Compare[int])
+		t2 := TreeSetFrom[int]([]int{2}, cmp.Compare[int])
 		result := t1.Union(t2)
 		must.NotEmpty(t, result)
 		must.Eq(t, []int{1, 2, 3}, result.Slice())
 	})
 
 	t.Run("superset", func(t *testing.T) {
-		t1 := TreeSetFrom[int]([]int{2, 3, 1}, Compare[int])
-		t2 := TreeSetFrom[int]([]int{2, 5, 1, 2, 4}, Compare[int])
+		t1 := TreeSetFrom[int]([]int{2, 3, 1}, cmp.Compare[int])
+		t2 := TreeSetFrom[int]([]int{2, 5, 1, 2, 4}, cmp.Compare[int])
 		result := t1.Union(t2)
 		must.NotEmpty(t, result)
 		must.Eq(t, []int{1, 2, 3, 4, 5}, result.Slice())
@@ -422,37 +423,37 @@ func TestTreeSet_Union(t *testing.T) {
 
 func TestTreeSet_Difference(t *testing.T) {
 	t.Run("empty empty", func(t *testing.T) {
-		t1 := TreeSetFrom[int](nil, Compare[int])
-		t2 := TreeSetFrom[int](nil, Compare[int])
+		t1 := TreeSetFrom[int](nil, cmp.Compare[int])
+		t2 := TreeSetFrom[int](nil, cmp.Compare[int])
 		result := t1.Difference(t2)
 		must.Empty(t, result)
 	})
 
 	t.Run("empty full", func(t *testing.T) {
-		t1 := TreeSetFrom[int](nil, Compare[int])
-		t2 := TreeSetFrom[int]([]int{1, 2, 3}, Compare[int])
+		t1 := TreeSetFrom[int](nil, cmp.Compare[int])
+		t2 := TreeSetFrom[int]([]int{1, 2, 3}, cmp.Compare[int])
 		result := t1.Difference(t2)
 		must.Empty(t, result)
 	})
 
 	t.Run("full empty", func(t *testing.T) {
-		t1 := TreeSetFrom[int]([]int{2, 1, 3}, Compare[int])
-		t2 := TreeSetFrom[int](nil, Compare[int])
+		t1 := TreeSetFrom[int]([]int{2, 1, 3}, cmp.Compare[int])
+		t2 := TreeSetFrom[int](nil, cmp.Compare[int])
 		result := t1.Difference(t2)
 		must.NotEmpty(t, result)
 		must.Eq(t, []int{1, 2, 3}, result.Slice())
 	})
 
 	t.Run("subset", func(t *testing.T) {
-		t1 := TreeSetFrom[int]([]int{3, 2, 4}, Compare[int])
-		t2 := TreeSetFrom[int]([]int{1, 2, 3, 4, 5}, Compare[int])
+		t1 := TreeSetFrom[int]([]int{3, 2, 4}, cmp.Compare[int])
+		t2 := TreeSetFrom[int]([]int{1, 2, 3, 4, 5}, cmp.Compare[int])
 		result := t1.Difference(t2)
 		must.Empty(t, result)
 	})
 
 	t.Run("superset", func(t *testing.T) {
-		t1 := TreeSetFrom[int]([]int{2, 1, 3, 4, 5}, Compare[int])
-		t2 := TreeSetFrom[int]([]int{1, 2, 5}, Compare[int])
+		t1 := TreeSetFrom[int]([]int{2, 1, 3, 4, 5}, cmp.Compare[int])
+		t2 := TreeSetFrom[int]([]int{1, 2, 5}, cmp.Compare[int])
 		result := t1.Difference(t2)
 		must.NotEmpty(t, result)
 		must.Eq(t, []int{3, 4}, result.Slice())
@@ -461,29 +462,29 @@ func TestTreeSet_Difference(t *testing.T) {
 
 func TestTreeSet_Intersect(t *testing.T) {
 	t.Run("empty empty", func(t *testing.T) {
-		t1 := TreeSetFrom[int](nil, Compare[int])
-		t2 := TreeSetFrom[int](nil, Compare[int])
+		t1 := TreeSetFrom[int](nil, cmp.Compare[int])
+		t2 := TreeSetFrom[int](nil, cmp.Compare[int])
 		result := t1.Intersect(t2)
 		must.Empty(t, result)
 	})
 
 	t.Run("empty full", func(t *testing.T) {
-		t1 := TreeSetFrom[int](nil, Compare[int])
-		t2 := TreeSetFrom[int]([]int{1, 2, 3}, Compare[int])
+		t1 := TreeSetFrom[int](nil, cmp.Compare[int])
+		t2 := TreeSetFrom[int]([]int{1, 2, 3}, cmp.Compare[int])
 		result := t1.Intersect(t2)
 		must.Empty(t, result)
 	})
 
 	t.Run("full empty", func(t *testing.T) {
-		t1 := TreeSetFrom[int]([]int{1, 2, 3}, Compare[int])
-		t2 := TreeSetFrom[int](nil, Compare[int])
+		t1 := TreeSetFrom[int]([]int{1, 2, 3}, cmp.Compare[int])
+		t2 := TreeSetFrom[int](nil, cmp.Compare[int])
 		result := t1.Intersect(t2)
 		must.Empty(t, result)
 	})
 
 	t.Run("overlap", func(t *testing.T) {
-		t1 := TreeSetFrom[int]([]int{1, 2, 3, 4, 5, 6}, Compare[int])
-		t2 := TreeSetFrom[int]([]int{0, 4, 5, 7}, Compare[int])
+		t1 := TreeSetFrom[int]([]int{1, 2, 3, 4, 5, 6}, cmp.Compare[int])
+		t2 := TreeSetFrom[int]([]int{0, 4, 5, 7}, cmp.Compare[int])
 		result := t1.Intersect(t2)
 		must.NotEmpty(t, result)
 		must.Eq(t, []int{4, 5}, result.Slice())
@@ -492,20 +493,20 @@ func TestTreeSet_Intersect(t *testing.T) {
 
 func TestTreeSet_Copy(t *testing.T) {
 	t.Run("empty", func(t *testing.T) {
-		t1 := NewTreeSet[int](Compare[int])
+		t1 := NewTreeSet[int](cmp.Compare[int])
 		c := t1.Copy()
 		must.Empty(t, c)
 	})
 
 	t.Run("full", func(t *testing.T) {
-		t1 := TreeSetFrom[int]([]int{1, 2, 3}, Compare[int])
+		t1 := TreeSetFrom[int]([]int{1, 2, 3}, cmp.Compare[int])
 		c := t1.Copy()
 		must.NotEmpty(t, c)
 		must.Eq(t, []int{1, 2, 3}, c.Slice())
 	})
 
 	t.Run("modify", func(t *testing.T) {
-		t1 := TreeSetFrom[int]([]int{1, 2, 3}, Compare[int])
+		t1 := TreeSetFrom[int]([]int{1, 2, 3}, cmp.Compare[int])
 		c := t1.Copy()
 		c.Insert(4)
 		t1.Remove(2)
@@ -516,88 +517,88 @@ func TestTreeSet_Copy(t *testing.T) {
 
 func TestTreeSet_EqualSlice(t *testing.T) {
 	t.Run("empty empty", func(t *testing.T) {
-		ts := TreeSetFrom[int](nil, Compare[int])
+		ts := TreeSetFrom[int](nil, cmp.Compare[int])
 		must.True(t, ts.EqualSlice(nil))
 	})
 
 	t.Run("empty full", func(t *testing.T) {
-		ts := TreeSetFrom[int](nil, Compare[int])
+		ts := TreeSetFrom[int](nil, cmp.Compare[int])
 		must.False(t, ts.EqualSlice([]int{1, 2, 3}))
 	})
 
 	t.Run("matching", func(t *testing.T) {
-		ts := TreeSetFrom[int]([]int{1, 2, 3, 4, 5, 6}, Compare[int])
+		ts := TreeSetFrom[int]([]int{1, 2, 3, 4, 5, 6}, cmp.Compare[int])
 		must.True(t, ts.EqualSlice([]int{3, 2, 1, 6, 5, 4}))
 	})
 
 	t.Run("different middle", func(t *testing.T) {
-		ts := TreeSetFrom[int]([]int{1, 2, 3, 5, 6}, Compare[int])
+		ts := TreeSetFrom[int]([]int{1, 2, 3, 5, 6}, cmp.Compare[int])
 		must.False(t, ts.EqualSlice([]int{3, 2, 9, 6, 5, 4}))
 	})
 }
 
 func TestTreeSet_Equal(t *testing.T) {
 	t.Run("empty empty", func(t *testing.T) {
-		t1 := TreeSetFrom[int](nil, Compare[int])
-		t2 := TreeSetFrom[int](nil, Compare[int])
+		t1 := TreeSetFrom[int](nil, cmp.Compare[int])
+		t2 := TreeSetFrom[int](nil, cmp.Compare[int])
 		must.Equal(t, t1, t2)
 	})
 
 	t.Run("empty full", func(t *testing.T) {
-		t1 := TreeSetFrom[int](nil, Compare[int])
-		t2 := TreeSetFrom[int]([]int{1, 2, 3}, Compare[int])
+		t1 := TreeSetFrom[int](nil, cmp.Compare[int])
+		t2 := TreeSetFrom[int]([]int{1, 2, 3}, cmp.Compare[int])
 		must.NotEqual(t, t1, t2)
 	})
 
 	t.Run("matching", func(t *testing.T) {
-		t1 := TreeSetFrom[int]([]int{1, 2, 3, 4, 5, 6}, Compare[int])
-		t2 := TreeSetFrom[int]([]int{6, 5, 4, 3, 2, 1}, Compare[int])
+		t1 := TreeSetFrom[int]([]int{1, 2, 3, 4, 5, 6}, cmp.Compare[int])
+		t2 := TreeSetFrom[int]([]int{6, 5, 4, 3, 2, 1}, cmp.Compare[int])
 		must.Equal(t, t1, t2)
 	})
 
 	t.Run("different min", func(t *testing.T) {
-		t1 := TreeSetFrom[int]([]int{1, 2, 3, 4}, Compare[int])
-		t2 := TreeSetFrom[int]([]int{0, 2, 3, 4}, Compare[int])
+		t1 := TreeSetFrom[int]([]int{1, 2, 3, 4}, cmp.Compare[int])
+		t2 := TreeSetFrom[int]([]int{0, 2, 3, 4}, cmp.Compare[int])
 		must.NotEqual(t, t1, t2)
 	})
 
 	t.Run("different max", func(t *testing.T) {
-		t1 := TreeSetFrom[int]([]int{1, 2, 3, 4}, Compare[int])
-		t2 := TreeSetFrom[int]([]int{5, 3, 2, 1}, Compare[int])
+		t1 := TreeSetFrom[int]([]int{1, 2, 3, 4}, cmp.Compare[int])
+		t2 := TreeSetFrom[int]([]int{5, 3, 2, 1}, cmp.Compare[int])
 		must.NotEqual(t, t1, t2)
 	})
 
 	t.Run("different middle", func(t *testing.T) {
-		t1 := TreeSetFrom[int]([]int{1, 2, 3, 5, 6}, Compare[int])
-		t2 := TreeSetFrom[int]([]int{1, 2, 4, 5, 6}, Compare[int])
+		t1 := TreeSetFrom[int]([]int{1, 2, 3, 5, 6}, cmp.Compare[int])
+		t2 := TreeSetFrom[int]([]int{1, 2, 4, 5, 6}, cmp.Compare[int])
 		must.NotEqual(t, t1, t2)
 	})
 }
 
 func TestTreeSet_EqualSet(t *testing.T) {
 	t.Run("empty empty", func(t *testing.T) {
-		t1 := TreeSetFrom[int](nil, Compare[int])
-		t2 := TreeSetFrom[int](nil, Compare[int])
+		t1 := TreeSetFrom[int](nil, cmp.Compare[int])
+		t2 := TreeSetFrom[int](nil, cmp.Compare[int])
 		must.True(t, t1.EqualSet(t2))
 	})
 
 	t.Run("empty full", func(t *testing.T) {
-		t1 := TreeSetFrom[int](nil, Compare[int])
-		t2 := TreeSetFrom[int]([]int{1, 2, 3}, Compare[int])
+		t1 := TreeSetFrom[int](nil, cmp.Compare[int])
+		t2 := TreeSetFrom[int]([]int{1, 2, 3}, cmp.Compare[int])
 		must.False(t, t1.EqualSet(t2))
 		must.False(t, t2.EqualSet(t1))
 	})
 
 	t.Run("different", func(t *testing.T) {
-		t1 := TreeSetFrom[int]([]int{1, 2, 4}, Compare[int])
-		t2 := TreeSetFrom[int]([]int{1, 2, 3}, Compare[int])
+		t1 := TreeSetFrom[int]([]int{1, 2, 4}, cmp.Compare[int])
+		t2 := TreeSetFrom[int]([]int{1, 2, 3}, cmp.Compare[int])
 		must.False(t, t1.EqualSet(t2))
 		must.False(t, t2.EqualSet(t1))
 	})
 
 	t.Run("same", func(t *testing.T) {
-		t1 := TreeSetFrom[int]([]int{1, 2, 3}, Compare[int])
-		t2 := TreeSetFrom[int]([]int{1, 2, 3}, Compare[int])
+		t1 := TreeSetFrom[int]([]int{1, 2, 3}, cmp.Compare[int])
+		t2 := TreeSetFrom[int]([]int{1, 2, 3}, cmp.Compare[int])
 		must.True(t, t1.EqualSet(t2))
 		must.True(t, t2.EqualSet(t1))
 	})
@@ -605,19 +606,19 @@ func TestTreeSet_EqualSet(t *testing.T) {
 
 func TestTreeSet_TopK(t *testing.T) {
 	t.Run("empty", func(t *testing.T) {
-		ts := NewTreeSet[int](Compare[int])
+		ts := NewTreeSet[int](cmp.Compare[int])
 		result := ts.TopK(5)
 		must.Eq(t, []int{}, result)
 	})
 
 	t.Run("same size", func(t *testing.T) {
-		ts := TreeSetFrom[int]([]int{3, 9, 1, 7, 5}, Compare[int])
+		ts := TreeSetFrom[int]([]int{3, 9, 1, 7, 5}, cmp.Compare[int])
 		result := ts.TopK(5)
 		must.Eq(t, []int{1, 3, 5, 7, 9}, result)
 	})
 
 	t.Run("smaller k", func(t *testing.T) {
-		ts := TreeSetFrom[int]([]int{3, 9, 1, 7, 5}, Compare[int])
+		ts := TreeSetFrom[int]([]int{3, 9, 1, 7, 5}, cmp.Compare[int])
 		result := ts.TopK(3)
 		must.Eq(t, []int{1, 3, 5}, result)
 	})
@@ -625,19 +626,19 @@ func TestTreeSet_TopK(t *testing.T) {
 
 func TestTreeSet_BottomK(t *testing.T) {
 	t.Run("empty", func(t *testing.T) {
-		ts := NewTreeSet[int](Compare[int])
+		ts := NewTreeSet[int](cmp.Compare[int])
 		result := ts.BottomK(5)
 		must.Eq(t, []int{}, result)
 	})
 
 	t.Run("same size", func(t *testing.T) {
-		ts := TreeSetFrom[int]([]int{3, 9, 1, 7, 5}, Compare[int])
+		ts := TreeSetFrom[int]([]int{3, 9, 1, 7, 5}, cmp.Compare[int])
 		result := ts.BottomK(5)
 		must.Eq(t, []int{9, 7, 5, 3, 1}, result)
 	})
 
 	t.Run("smaller k", func(t *testing.T) {
-		ts := TreeSetFrom[int]([]int{3, 9, 1, 7, 5}, Compare[int])
+		ts := TreeSetFrom[int]([]int{3, 9, 1, 7, 5}, cmp.Compare[int])
 		result := ts.BottomK(3)
 		must.Eq(t, []int{9, 7, 5}, result)
 	})
@@ -645,20 +646,20 @@ func TestTreeSet_BottomK(t *testing.T) {
 
 func TestTreeSet_FirstBelow(t *testing.T) {
 	t.Run("empty", func(t *testing.T) {
-		ts := NewTreeSet[int](Compare[int])
+		ts := NewTreeSet[int](cmp.Compare[int])
 		_, exists := ts.FirstBelow(5)
 		must.False(t, exists)
 	})
 
 	t.Run("basic", func(t *testing.T) {
-		ts := TreeSetFrom[int]([]int{1, 3, 4, 5, 7, 8}, Compare[int])
+		ts := TreeSetFrom[int]([]int{1, 3, 4, 5, 7, 8}, cmp.Compare[int])
 		v, exists := ts.FirstBelow(5)
 		must.True(t, exists)
 		must.Eq(t, 4, v)
 	})
 
 	t.Run("many", func(t *testing.T) {
-		ts := NewTreeSet[int](Compare[int])
+		ts := NewTreeSet[int](cmp.Compare[int])
 		nums := shuffle(ints(100))
 		ts.InsertSlice(nums)
 		for i := 2; i < 100; i++ {
@@ -671,20 +672,20 @@ func TestTreeSet_FirstBelow(t *testing.T) {
 
 func TestTreeSet_FirstBelowEqual(t *testing.T) {
 	t.Run("empty", func(t *testing.T) {
-		ts := NewTreeSet[int](Compare[int])
+		ts := NewTreeSet[int](cmp.Compare[int])
 		_, exists := ts.FirstBelowEqual(5)
 		must.False(t, exists)
 	})
 
 	t.Run("basic", func(t *testing.T) {
-		ts := TreeSetFrom[int]([]int{1, 3, 4, 5, 7, 8}, Compare[int])
+		ts := TreeSetFrom[int]([]int{1, 3, 4, 5, 7, 8}, cmp.Compare[int])
 		v, exists := ts.FirstBelowEqual(5)
 		must.True(t, exists)
 		must.Eq(t, 5, v)
 	})
 
 	t.Run("many", func(t *testing.T) {
-		ts := NewTreeSet[int](Compare[int])
+		ts := NewTreeSet[int](cmp.Compare[int])
 		nums := shuffle(ints(100))
 		ts.InsertSlice(nums)
 		for i := 1; i < 100; i++ {
@@ -697,20 +698,20 @@ func TestTreeSet_FirstBelowEqual(t *testing.T) {
 
 func TestTreeSet_Below(t *testing.T) {
 	t.Run("empty", func(t *testing.T) {
-		ts := TreeSetFrom[int]([]int{5, 6, 7, 8, 9}, Compare[int])
+		ts := TreeSetFrom[int]([]int{5, 6, 7, 8, 9}, cmp.Compare[int])
 		b := ts.Below(5)
 		must.Empty(t, b)
 	})
 
 	t.Run("basic", func(t *testing.T) {
-		ts := TreeSetFrom[int]([]int{4, 7, 1, 5, 2, 8, 9, 3}, Compare[int])
+		ts := TreeSetFrom[int]([]int{4, 7, 1, 5, 2, 8, 9, 3}, cmp.Compare[int])
 		b := ts.Below(5)
 		result := b.Slice()
 		must.Eq(t, []int{1, 2, 3, 4}, result)
 	})
 
 	t.Run("many", func(t *testing.T) {
-		ts := NewTreeSet[int](Compare[int])
+		ts := NewTreeSet[int](cmp.Compare[int])
 		nums := shuffle(ints(100))
 		ts.InsertSlice(nums)
 		for i := 2; i < 100; i++ {
@@ -724,20 +725,20 @@ func TestTreeSet_Below(t *testing.T) {
 
 func TestTreeSet_BelowEqual(t *testing.T) {
 	t.Run("empty", func(t *testing.T) {
-		ts := TreeSetFrom[int]([]int{5, 6, 7, 8, 9}, Compare[int])
+		ts := TreeSetFrom[int]([]int{5, 6, 7, 8, 9}, cmp.Compare[int])
 		b := ts.BelowEqual(4)
 		must.Empty(t, b)
 	})
 
 	t.Run("basic", func(t *testing.T) {
-		ts := TreeSetFrom[int]([]int{4, 7, 1, 5, 2, 8, 9, 3}, Compare[int])
+		ts := TreeSetFrom[int]([]int{4, 7, 1, 5, 2, 8, 9, 3}, cmp.Compare[int])
 		b := ts.BelowEqual(5)
 		result := b.Slice()
 		must.Eq(t, []int{1, 2, 3, 4, 5}, result)
 	})
 
 	t.Run("many", func(t *testing.T) {
-		ts := NewTreeSet[int](Compare[int])
+		ts := NewTreeSet[int](cmp.Compare[int])
 		nums := shuffle(ints(100))
 		ts.InsertSlice(nums)
 		for i := 1; i < 100; i++ {
@@ -751,20 +752,20 @@ func TestTreeSet_BelowEqual(t *testing.T) {
 
 func TestTreeSet_FirstAbove(t *testing.T) {
 	t.Run("empty", func(t *testing.T) {
-		ts := TreeSetFrom[int]([]int{2, 1, 3, 5, 4}, Compare[int])
+		ts := TreeSetFrom[int]([]int{2, 1, 3, 5, 4}, cmp.Compare[int])
 		_, exists := ts.FirstAbove(5)
 		must.False(t, exists)
 	})
 
 	t.Run("basic", func(t *testing.T) {
-		ts := TreeSetFrom[int]([]int{2, 1, 4, 6, 5, 7, 8}, Compare[int])
+		ts := TreeSetFrom[int]([]int{2, 1, 4, 6, 5, 7, 8}, cmp.Compare[int])
 		v, exists := ts.FirstAbove(5)
 		must.True(t, exists)
 		must.Eq(t, 6, v)
 	})
 
 	t.Run("many", func(t *testing.T) {
-		ts := NewTreeSet[int](Compare[int])
+		ts := NewTreeSet[int](cmp.Compare[int])
 		nums := shuffle(ints(100))
 		ts.InsertSlice(nums)
 		for i := 1; i < 100; i++ {
@@ -777,20 +778,20 @@ func TestTreeSet_FirstAbove(t *testing.T) {
 
 func TestTreeSet_FirstAboveEqual(t *testing.T) {
 	t.Run("empty", func(t *testing.T) {
-		ts := TreeSetFrom[int]([]int{2, 1, 3, 4}, Compare[int])
+		ts := TreeSetFrom[int]([]int{2, 1, 3, 4}, cmp.Compare[int])
 		_, exists := ts.FirstAboveEqual(5)
 		must.False(t, exists)
 	})
 
 	t.Run("basic", func(t *testing.T) {
-		ts := TreeSetFrom[int]([]int{2, 1, 4, 6, 5, 7, 8}, Compare[int])
+		ts := TreeSetFrom[int]([]int{2, 1, 4, 6, 5, 7, 8}, cmp.Compare[int])
 		v, exists := ts.FirstAboveEqual(5)
 		must.True(t, exists)
 		must.Eq(t, 5, v)
 	})
 
 	t.Run("many", func(t *testing.T) {
-		ts := NewTreeSet[int](Compare[int])
+		ts := NewTreeSet[int](cmp.Compare[int])
 		nums := shuffle(ints(100))
 		ts.InsertSlice(nums)
 		for i := 1; i < 100; i++ {
@@ -803,20 +804,20 @@ func TestTreeSet_FirstAboveEqual(t *testing.T) {
 
 func TestTreeSet_Above(t *testing.T) {
 	t.Run("empty", func(t *testing.T) {
-		ts := TreeSetFrom[int]([]int{5, 6, 7, 8, 9}, Compare[int])
+		ts := TreeSetFrom[int]([]int{5, 6, 7, 8, 9}, cmp.Compare[int])
 		b := ts.Above(9)
 		must.Empty(t, b)
 	})
 
 	t.Run("basic", func(t *testing.T) {
-		ts := TreeSetFrom[int]([]int{4, 7, 1, 5, 2, 8, 9, 3}, Compare[int])
+		ts := TreeSetFrom[int]([]int{4, 7, 1, 5, 2, 8, 9, 3}, cmp.Compare[int])
 		b := ts.Above(5)
 		result := b.Slice()
 		must.Eq(t, []int{7, 8, 9}, result)
 	})
 
 	t.Run("many", func(t *testing.T) {
-		ts := NewTreeSet[int](Compare[int])
+		ts := NewTreeSet[int](cmp.Compare[int])
 		nums := shuffle(ints(100))
 		ts.InsertSlice(nums)
 		for i := 1; i < 100; i++ {
@@ -830,20 +831,20 @@ func TestTreeSet_Above(t *testing.T) {
 
 func TestTreeSet_AboveEqual(t *testing.T) {
 	t.Run("empty", func(t *testing.T) {
-		ts := TreeSetFrom[int]([]int{5, 6, 7, 8, 9}, Compare[int])
+		ts := TreeSetFrom[int]([]int{5, 6, 7, 8, 9}, cmp.Compare[int])
 		b := ts.AboveEqual(10)
 		must.Empty(t, b)
 	})
 
 	t.Run("basic", func(t *testing.T) {
-		ts := TreeSetFrom[int]([]int{4, 7, 1, 5, 2, 8, 9, 3}, Compare[int])
+		ts := TreeSetFrom[int]([]int{4, 7, 1, 5, 2, 8, 9, 3}, cmp.Compare[int])
 		b := ts.AboveEqual(5)
 		result := b.Slice()
 		must.Eq(t, []int{5, 7, 8, 9}, result)
 	})
 
 	t.Run("many", func(t *testing.T) {
-		ts := NewTreeSet[int](Compare[int])
+		ts := NewTreeSet[int](cmp.Compare[int])
 		nums := shuffle(ints(100))
 		ts.InsertSlice(nums)
 		for i := 1; i < 100; i++ {
@@ -857,13 +858,13 @@ func TestTreeSet_AboveEqual(t *testing.T) {
 
 func TestTreeSet_Slice(t *testing.T) {
 	t.Run("empty", func(t *testing.T) {
-		ts := NewTreeSet[int](Compare[int])
+		ts := NewTreeSet[int](cmp.Compare[int])
 		result := ts.Slice()
 		must.Eq(t, []int{}, result)
 	})
 
 	t.Run("full", func(t *testing.T) {
-		ts := TreeSetFrom[int]([]int{4, 2, 6, 1}, Compare[int])
+		ts := TreeSetFrom[int]([]int{4, 2, 6, 1}, cmp.Compare[int])
 		result := ts.Slice()
 		must.Eq(t, []int{1, 2, 4, 6}, result)
 	})
@@ -871,13 +872,13 @@ func TestTreeSet_Slice(t *testing.T) {
 
 func TestTreeSet_String(t *testing.T) {
 	t.Run("empty", func(t *testing.T) {
-		ts := NewTreeSet[int](Compare[int])
+		ts := NewTreeSet[int](cmp.Compare[int])
 		result := ts.String()
 		must.Eq(t, "[]", result)
 	})
 
 	t.Run("full", func(t *testing.T) {
-		ts := TreeSetFrom[int]([]int{4, 2, 6, 1}, Compare[int])
+		ts := TreeSetFrom[int]([]int{4, 2, 6, 1}, cmp.Compare[int])
 		result := ts.String()
 		must.Eq(t, "[1 2 4 6]", result)
 	})
@@ -886,13 +887,13 @@ func TestTreeSet_String(t *testing.T) {
 func TestTreeSet_StringFunc(t *testing.T) {
 	f := func(i int) string { return fmt.Sprintf("%02d", i) }
 	t.Run("empty", func(t *testing.T) {
-		ts := NewTreeSet[int](Compare[int])
+		ts := NewTreeSet[int](cmp.Compare[int])
 		result := ts.StringFunc(f)
 		must.Eq(t, "[]", result)
 	})
 
 	t.Run("full", func(t *testing.T) {
-		ts := TreeSetFrom[int]([]int{4, 2, 6, 1}, Compare[int])
+		ts := TreeSetFrom[int]([]int{4, 2, 6, 1}, cmp.Compare[int])
 		result := ts.StringFunc(f)
 		must.Eq(t, "[01 02 04 06]", result)
 	})
@@ -983,7 +984,7 @@ func shuffle(s []int) []int {
 }
 
 func TestTreeSet_infix(t *testing.T) {
-	ts := TreeSetFrom[int]([]int{4, 7, 1, 5, 2, 8, 9, 3, 11, 13}, Compare[int])
+	ts := TreeSetFrom[int]([]int{4, 7, 1, 5, 2, 8, 9, 3, 11, 13}, cmp.Compare[int])
 	isOdd := func(n *node[int]) bool {
 		return n.element%2 == 1
 	}
@@ -1003,7 +1004,7 @@ func TestTreeSet_infix(t *testing.T) {
 
 func TestTreeSet_iterate2(t *testing.T) {
 	nums := shuffle(ints(11))
-	s := TreeSetFrom[int](nums, Compare[int])
+	s := TreeSetFrom[int](nums, cmp.Compare[int])
 
 	iter := s.iterate()
 	for i := 1; i <= 11; i++ {
@@ -1013,7 +1014,7 @@ func TestTreeSet_iterate2(t *testing.T) {
 }
 
 func TestTreeSet_Items(t *testing.T) {
-	ts := TreeSetFrom[int]([]int{2, 1, 4, 3, 5}, Compare[int])
+	ts := TreeSetFrom[int]([]int{2, 1, 4, 3, 5}, cmp.Compare[int])
 
 	exp := []int{1, 2, 3, 4, 5}
 	result := []int{}


### PR DESCRIPTION
The standard library now has `cmp.Ordered` and `cmp.Compare` which are
basically the same things. Replace our custom types with the standard
library types.

https://pkg.go.dev/cmp

Closes #89
