### PR TITLE
remove flaky example JSON marshalling tests

### DIFF
--- a/examples_hashset_test.go
+++ b/examples_hashset_test.go
@@ -4,7 +4,6 @@
 package set
 
 import (
-	"encoding/json"
 	"fmt"
 	"sort"
 )
@@ -381,25 +380,4 @@ func ExampleHashSet_UnmarshalJSON() {
 	// fmt.Println(out.Persons)
 
 	// Output:
-}
-
-func ExampleHashSet_MarshalJSON() {
-	type Foo struct {
-		Persons *HashSet[*person, string] `json:"persons"`
-	}
-
-	f := Foo{
-		Persons: HashSetFrom([]*person{
-			{Name: "anna", ID: 94},
-			{Name: "bill", ID: 50},
-			{Name: "carl", ID: 10},
-		}),
-	}
-
-	b, _ := json.Marshal(f)
-
-	fmt.Println(string(b))
-
-	// Output:
-	// {"persons":[{"Name":"anna","ID":94},{"Name":"bill","ID":50},{"Name":"carl","ID":10}]}
 }

--- a/examples_set_test.go
+++ b/examples_set_test.go
@@ -273,20 +273,3 @@ func ExampleSet_UnmarshalJSON() {
 	// Output:
 	// [blue green red]
 }
-
-func ExampleSet_MarshalJSON() {
-	type Foo struct {
-		Colors *Set[string] `json:"colors"`
-	}
-
-	f := Foo{
-		Colors: From([]string{"red", "green", "blue"}),
-	}
-
-	b, _ := json.Marshal(f)
-
-	fmt.Println(string(b))
-
-	// Output:
-	// {"colors":["red","green","blue"]}
-}


### PR DESCRIPTION
Because `Set` and `HashSet` are unsorted, the output of marshalling them to JSON is unstable, and this makes for flaky example tests. Given that we have an equivalent test for `TreeSet` and we can roughly be assured that Go developers know how to call the JSON serialization functions, we can just eliminate these.