### PR TITLE
optimize TreeSet.EqualSliceSet to avoid unnecessary tree allocation

### DIFF
--- a/treeset.go
+++ b/treeset.go
@@ -6,6 +6,7 @@ package set
 import (
 	"fmt"
 	"iter"
+	"slices"
 )
 
 // CompareFunc represents a function that compares two elements.
@@ -463,11 +464,24 @@ func (s *TreeSet[T]) EqualSlice(items []T) bool {
 //
 // To detect if a slice is a subset of s, use ContainsSlice.
 func (s *TreeSet[T]) EqualSliceSet(items []T) bool {
-	// TODO optimize
 	if s.Size() != len(items) {
 		return false
 	}
-	return s.EqualSlice(items)
+	if s.Size() == 0 {
+		return true
+	}
+	sorted := make([]T, len(items))
+	copy(sorted, items)
+	slices.SortFunc(sorted, s.comparison)
+
+	iterS := s.iterate()
+	for _, item := range sorted {
+		n := iterS()
+		if s.comparison(n.element, item) != 0 {
+			return false
+		}
+	}
+	return true
 }
 
 // String creates a string representation of s, using "%v" printf formatting

--- a/treeset_test.go
+++ b/treeset_test.go
@@ -537,6 +537,60 @@ func TestTreeSet_EqualSlice(t *testing.T) {
 	})
 }
 
+func TestTreeSet_EqualSliceSet(t *testing.T) {
+	t.Run("empty empty", func(t *testing.T) {
+		ts := TreeSetFrom[int](nil, cmp.Compare[int])
+		must.True(t, ts.EqualSliceSet(nil))
+	})
+
+	t.Run("empty set full slice", func(t *testing.T) {
+		ts := TreeSetFrom[int](nil, cmp.Compare[int])
+		must.False(t, ts.EqualSliceSet([]int{1, 2, 3}))
+	})
+
+	t.Run("full set empty slice", func(t *testing.T) {
+		ts := TreeSetFrom[int]([]int{1, 2, 3}, cmp.Compare[int])
+		must.False(t, ts.EqualSliceSet(nil))
+	})
+
+	t.Run("single element match", func(t *testing.T) {
+		ts := TreeSetFrom[int]([]int{42}, cmp.Compare[int])
+		must.True(t, ts.EqualSliceSet([]int{42}))
+	})
+
+	t.Run("single element mismatch", func(t *testing.T) {
+		ts := TreeSetFrom[int]([]int{42}, cmp.Compare[int])
+		must.False(t, ts.EqualSliceSet([]int{7}))
+	})
+
+	t.Run("matching unsorted slice", func(t *testing.T) {
+		ts := TreeSetFrom[int]([]int{1, 2, 3, 4, 5, 6}, cmp.Compare[int])
+		must.True(t, ts.EqualSliceSet([]int{6, 3, 1, 5, 2, 4}))
+	})
+
+	t.Run("different middle", func(t *testing.T) {
+		ts := TreeSetFrom[int]([]int{1, 2, 3, 5, 6}, cmp.Compare[int])
+		must.False(t, ts.EqualSliceSet([]int{1, 2, 4, 5, 6}))
+	})
+
+	t.Run("duplicates in slice increase length", func(t *testing.T) {
+		ts := TreeSetFrom[int]([]int{1, 2, 3, 4}, cmp.Compare[int])
+		must.False(t, ts.EqualSliceSet([]int{1, 1, 2, 3, 4}))
+	})
+
+	t.Run("duplicates in slice same length", func(t *testing.T) {
+		ts := TreeSetFrom[int]([]int{1, 2, 3, 4}, cmp.Compare[int])
+		must.False(t, ts.EqualSliceSet([]int{1, 1, 2, 4}))
+	})
+
+	t.Run("does not mutate caller slice", func(t *testing.T) {
+		ts := TreeSetFrom[int]([]int{1, 2, 3}, cmp.Compare[int])
+		input := []int{3, 1, 2}
+		must.True(t, ts.EqualSliceSet(input))
+		must.Eq(t, []int{3, 1, 2}, input)
+	})
+}
+
 func TestTreeSet_Equal(t *testing.T) {
 	t.Run("empty empty", func(t *testing.T) {
 		t1 := TreeSetFrom[int](nil, cmp.Compare[int])


### PR DESCRIPTION
Fixes #109
**EqualSliceSet** was calling **EqualSlice**, which calls **TreeSetFrom** internally so it was building a whole Red-Black tree from items just to compare it and throw it away immediately. Every element meant a heap allocation for a node[T] and tree insertion work, none of which was needed just to check equality.

**The fix:** copy items into **sorted**, sort it with **slices.SortFunc** using **s.comparison** (the same function the tree already uses), then walk **s.iterate()** and sorted together and compare element by element. The tree iterates in ascending order, and **slices.SortFunc** with the same comparator gives the same order on the slice, so the pairs line up. On the duplicate question from the issue duplicates aren't contractually ruled out, the function just returns false when they appear. Both cases are handled correctly here:

- duplicates that make **len(items) > s.Size()** get caught by the size check at the top
- duplicates that leave the length equal (e.g. set is {1,2,3,4}, items is [1,1,2,4]) get caught by the lock-step walk because after sorting, **sorted[1]** is 1 but the tree yields 2 mismatch, returns false

**sorted** is a copy so the caller's slice order is never touched. Added **"slices"** to the import, which is stdlib, no new dependency.

Added **TestTreeSet_EqualSliceSet** with 10 sub-tests: both empty, empty vs non-empty in both directions, single element match and mismatch, unsorted matching slice, differing middle element, duplicate that increases length, duplicate at equal length, and a check that the original slice isn't mutated.

**AI usage:** Used GitHub Copilot to help draft the implementation and tests. Reviewed and understood every line before committing. All tests pass.